### PR TITLE
Upgrading Guava to 18.0 and setting test jar scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,7 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>
@@ -129,6 +130,7 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>1.8.4</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Please consider the upgrade to guava 18.0 and setting test jar scope to 'test'. Thanks!
