### PR TITLE
(#300) Wrap `is_private_session` flag 

### DIFF
--- a/src/main/java/se/michaelthelin/spotify/model_objects/miscellaneous/Device.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/miscellaneous/Device.java
@@ -49,14 +49,13 @@ public class Device extends AbstractModelObject {
   }
 
   /**
-   * Get whether the device is a private session. Access to playback info is limited on private session clients.
+   * Get whether the device is in a private session. Access to playback info is limited on clients in a private session.
    *
-   * @return whether the user has put the client into a private session.
+   * @return Whether the user has put the client into a private session.
    */
   public Boolean getIs_private_session() {
     return is_private_session;
   }
-
 
   /**
    * Check whether the device is restricted or not. Restricted devices don't accept Spotify Web API calls.
@@ -142,7 +141,7 @@ public class Device extends AbstractModelObject {
     /**
      * The private session state setter.
      *
-     * @param is_private_session If this device is the currently active device.
+     * @param is_private_session If this device is currently in a private session.
      * @return A {@link Device.Builder}.
      */
     public Builder setIs_private_session(Boolean is_private_session) {

--- a/src/main/java/se/michaelthelin/spotify/model_objects/miscellaneous/Device.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/miscellaneous/Device.java
@@ -12,6 +12,7 @@ import se.michaelthelin.spotify.model_objects.AbstractModelObject;
 public class Device extends AbstractModelObject {
   private final String id;
   private final Boolean is_active;
+  private final Boolean is_private_session;
   private final Boolean is_restricted;
   private final String name;
   private final String type;
@@ -22,6 +23,7 @@ public class Device extends AbstractModelObject {
 
     this.id = builder.id;
     this.is_active = builder.is_active;
+    this.is_private_session = builder.is_private_session;
     this.is_restricted = builder.is_restricted;
     this.name = builder.name;
     this.type = builder.type;
@@ -45,6 +47,16 @@ public class Device extends AbstractModelObject {
   public Boolean getIs_active() {
     return is_active;
   }
+
+  /**
+   * Get whether the device is a private session. Access to playback info is limited on private session clients.
+   *
+   * @return whether the user has put the client into a private session.
+   */
+  public Boolean getIs_private_session() {
+    return is_private_session;
+  }
+
 
   /**
    * Check whether the device is restricted or not. Restricted devices don't accept Spotify Web API calls.
@@ -84,7 +96,7 @@ public class Device extends AbstractModelObject {
 
   @Override
   public String toString() {
-    return "Device(id=" + id + ", is_active=" + is_active + ", is_restricted=" + is_restricted + ", name=" + name
+    return "Device(id=" + id + ", is_active=" + is_active + ", is_private_session=" + is_private_session + ", is_restricted=" + is_restricted + ", name=" + name
         + ", type=" + type + ", volume_percent=" + volume_percent + ")";
   }
 
@@ -99,6 +111,7 @@ public class Device extends AbstractModelObject {
   public static final class Builder extends AbstractModelObject.Builder {
     private String id;
     private Boolean is_active;
+    private Boolean is_private_session;
     private Boolean is_restricted;
     private String name;
     private String type;
@@ -123,6 +136,17 @@ public class Device extends AbstractModelObject {
      */
     public Builder setIs_active(Boolean is_active) {
       this.is_active = is_active;
+      return this;
+    }
+
+    /**
+     * The private session state setter.
+     *
+     * @param is_private_session If this device is the currently active device.
+     * @return A {@link Device.Builder}.
+     */
+    public Builder setIs_private_session(Boolean is_private_session) {
+      this.is_private_session = is_private_session;
       return this;
     }
 
@@ -193,6 +217,10 @@ public class Device extends AbstractModelObject {
         .setIs_active(
           hasAndNotNull(jsonObject, "is_active")
             ? jsonObject.get("is_active").getAsBoolean()
+            : null)
+        .setIs_private_session(
+          hasAndNotNull(jsonObject, "is_private_session")
+            ? jsonObject.get("is_private_session").getAsBoolean()
             : null)
         .setIs_restricted(
           hasAndNotNull(jsonObject, "is_restricted")

--- a/src/test/fixtures/requests/data/player/GetInformationAboutUsersCurrentPlaybackRequest.json
+++ b/src/test/fixtures/requests/data/player/GetInformationAboutUsersCurrentPlaybackRequest.json
@@ -78,6 +78,7 @@
   "device": {
     "id": "5fbb3ba6aa454b5534c4ba43a8c7e8e45a63ad0e",
     "is_active": false,
+    "is_private_session": false,
     "is_restricted": false,
     "name": "My fridge",
     "type": "Computer",

--- a/src/test/fixtures/requests/data/player/GetUsersAvailableDevices.json
+++ b/src/test/fixtures/requests/data/player/GetUsersAvailableDevices.json
@@ -3,6 +3,7 @@
     {
       "id": "5fbb3ba6aa454b5534c4ba43a8c7e8e45a63ad0e",
       "is_active": false,
+      "is_private_session": false,
       "is_restricted": false,
       "name": "My fridge",
       "type": "Computer",


### PR DESCRIPTION
fixes #300 

- Device includes flag, it's getter, setter, and factory.
- Test data modified to include the flag.
- All existing tests pass.

Functionality tested live :

https://user-images.githubusercontent.com/50697488/184509305-2b3ec99a-6685-4269-94a3-9e04aa375425.mov

 