### PR TITLE
Upgrade to JUnit Jupiter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,9 +57,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.9.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/se/michaelthelin/spotify/Assertions.java
+++ b/src/test/java/se/michaelthelin/spotify/Assertions.java
@@ -6,7 +6,7 @@ import se.michaelthelin.spotify.requests.IRequest;
 
 import java.util.List;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class Assertions {
 

--- a/src/test/java/se/michaelthelin/spotify/requests/authorization/AbstractAuthorizationTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/authorization/AbstractAuthorizationTest.java
@@ -1,12 +1,13 @@
 package se.michaelthelin.spotify.requests.authorization;
 
-import se.michaelthelin.spotify.Assertions;
 import se.michaelthelin.spotify.ITest;
+
+import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 public abstract class AbstractAuthorizationTest<T> implements ITest<T> {
 
   public void assertHasAuthorizationHeader(AbstractAuthorizationRequest<T> request) {
-    Assertions.assertHasHeader(
+    assertHasHeader(
       request,
       "Authorization",
       "Basic enl1eGhmbzFjNTFiNWh4amswOXgydWh2NW4wc3ZnZDZnOnp1ZGtueXFiaDN3dW5iaGN2Zzl1eXZvN3V3emV1Nm5uZQ==");

--- a/src/test/java/se/michaelthelin/spotify/requests/authorization/authorization_code/AuthorizationCodeRefreshRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/authorization/authorization_code/AuthorizationCodeRefreshRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.authorization.authorization_code;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -11,7 +11,7 @@ import se.michaelthelin.spotify.requests.authorization.AbstractAuthorizationTest
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 

--- a/src/test/java/se/michaelthelin/spotify/requests/authorization/authorization_code/AuthorizationCodeRefreshRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/authorization/authorization_code/AuthorizationCodeRefreshRequestTest.java
@@ -1,9 +1,7 @@
 package se.michaelthelin.spotify.requests.authorization.authorization_code;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
-import se.michaelthelin.spotify.Assertions;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -14,6 +12,8 @@ import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
+import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
+import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 public class AuthorizationCodeRefreshRequestTest extends AbstractAuthorizationTest<AuthorizationCodeCredentials> {
 
@@ -31,16 +31,16 @@ public class AuthorizationCodeRefreshRequestTest extends AbstractAuthorizationTe
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assertions.assertHasHeader(defaultRequest, "Content-Type", "application/x-www-form-urlencoded");
-    Assertions.assertHasBodyParameter(
+    assertHasHeader(defaultRequest, "Content-Type", "application/x-www-form-urlencoded");
+    assertHasBodyParameter(
       defaultRequest,
       "grant_type",
       "refresh_token");
-    Assertions.assertHasBodyParameter(
+    assertHasBodyParameter(
       defaultRequest,
       "refresh_token",
       ITest.SPOTIFY_API.getRefreshToken());
-    Assert.assertEquals(
+    assertEquals(
       "https://accounts.spotify.com:443/api/token",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/authorization/authorization_code/AuthorizationCodeRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/authorization/authorization_code/AuthorizationCodeRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.authorization.authorization_code;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.credentials.AuthorizationCodeCredentials;
@@ -10,7 +10,7 @@ import se.michaelthelin.spotify.requests.authorization.AbstractAuthorizationTest
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 

--- a/src/test/java/se/michaelthelin/spotify/requests/authorization/authorization_code/AuthorizationCodeRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/authorization/authorization_code/AuthorizationCodeRequestTest.java
@@ -1,9 +1,7 @@
 package se.michaelthelin.spotify.requests.authorization.authorization_code;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
-import se.michaelthelin.spotify.Assertions;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.credentials.AuthorizationCodeCredentials;
@@ -13,6 +11,8 @@ import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
+import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
+import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 public class AuthorizationCodeRequestTest extends AbstractAuthorizationTest<AuthorizationCodeCredentials> {
 
@@ -30,20 +30,20 @@ public class AuthorizationCodeRequestTest extends AbstractAuthorizationTest<Auth
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assertions.assertHasHeader(defaultRequest, "Content-Type", "application/x-www-form-urlencoded");
-    Assertions.assertHasBodyParameter(
+    assertHasHeader(defaultRequest, "Content-Type", "application/x-www-form-urlencoded");
+    assertHasBodyParameter(
       defaultRequest,
       "code",
       AUTHORIZATION_CODE);
-    Assertions.assertHasBodyParameter(
+    assertHasBodyParameter(
       defaultRequest,
       "grant_type",
       "authorization_code");
-    Assertions.assertHasBodyParameter(
+    assertHasBodyParameter(
       defaultRequest,
       "redirect_uri",
       SPOTIFY_API.getRedirectURI());
-    Assert.assertEquals(
+    assertEquals(
       "https://accounts.spotify.com:443/api/token",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/authorization/authorization_code/AuthorizationCodeUriRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/authorization/authorization_code/AuthorizationCodeUriRequestTest.java
@@ -1,6 +1,5 @@
 package se.michaelthelin.spotify.requests.authorization.authorization_code;
 
-import org.junit.Assert;
 import org.junit.Test;
 import se.michaelthelin.spotify.ITest;
 
@@ -26,7 +25,7 @@ public class AuthorizationCodeUriRequestTest implements ITest<URI> {
 
   @Test
   public void shouldComplyWithReference() {
-    Assert.assertEquals(
+    assertEquals(
       "https://accounts.spotify.com:443/authorize?client_id=zyuxhfo1c51b5hxjk09x2uhv5n0svgd6g&response_type=code&redirect_uri=https%3A%2F%2Fexample.com%2Fspotify-redirect&scope=user-read-birthday%20user-read-email&show_dialog=true",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/authorization/authorization_code/AuthorizationCodeUriRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/authorization/authorization_code/AuthorizationCodeUriRequestTest.java
@@ -1,12 +1,12 @@
 package se.michaelthelin.spotify.requests.authorization.authorization_code;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 
 import java.net.URI;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AuthorizationCodeUriRequestTest implements ITest<URI> {
 

--- a/src/test/java/se/michaelthelin/spotify/requests/authorization/authorization_code/pkce/AuthorizationCodePKCERefreshRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/authorization/authorization_code/pkce/AuthorizationCodePKCERefreshRequestTest.java
@@ -2,7 +2,7 @@ package se.michaelthelin.spotify.requests.authorization.authorization_code.pkce;
 
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -11,7 +11,7 @@ import se.michaelthelin.spotify.model_objects.credentials.AuthorizationCodeCrede
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 

--- a/src/test/java/se/michaelthelin/spotify/requests/authorization/authorization_code/pkce/AuthorizationCodePKCERefreshRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/authorization/authorization_code/pkce/AuthorizationCodePKCERefreshRequestTest.java
@@ -2,9 +2,7 @@ package se.michaelthelin.spotify.requests.authorization.authorization_code.pkce;
 
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
-import se.michaelthelin.spotify.Assertions;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -14,6 +12,8 @@ import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
+import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
+import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 public class AuthorizationCodePKCERefreshRequestTest implements ITest<AuthorizationCodeCredentials> {
 
@@ -28,20 +28,20 @@ public class AuthorizationCodePKCERefreshRequestTest implements ITest<Authorizat
 
   @Test
   public void shouldComplyWithReference() {
-    Assertions.assertHasHeader(defaultRequest, "Content-Type", "application/x-www-form-urlencoded");
-    Assertions.assertHasBodyParameter(
+    assertHasHeader(defaultRequest, "Content-Type", "application/x-www-form-urlencoded");
+    assertHasBodyParameter(
       defaultRequest,
       "grant_type",
       "refresh_token");
-    Assertions.assertHasBodyParameter(
+    assertHasBodyParameter(
       defaultRequest,
       "refresh_token",
       SPOTIFY_API.getRefreshToken());
-    Assertions.assertHasBodyParameter(
+    assertHasBodyParameter(
       defaultRequest,
       "client_id",
       SPOTIFY_API.getClientId());
-    Assert.assertEquals(
+    assertEquals(
       "https://accounts.spotify.com:443/api/token",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/authorization/authorization_code/pkce/AuthorizationCodePKCERequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/authorization/authorization_code/pkce/AuthorizationCodePKCERequestTest.java
@@ -1,9 +1,7 @@
 package se.michaelthelin.spotify.requests.authorization.authorization_code.pkce;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
-import se.michaelthelin.spotify.Assertions;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -13,6 +11,8 @@ import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
+import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
+import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 public class AuthorizationCodePKCERequestTest implements ITest<AuthorizationCodeCredentials> {
 
@@ -27,27 +27,27 @@ public class AuthorizationCodePKCERequestTest implements ITest<AuthorizationCode
 
   @Test
   public void shouldComplyWithReference() {
-    Assertions.assertHasHeader(defaultRequest, "Content-Type", "application/x-www-form-urlencoded");
-    Assertions.assertHasBodyParameter(
+    assertHasHeader(defaultRequest, "Content-Type", "application/x-www-form-urlencoded");
+    assertHasBodyParameter(
       defaultRequest,
       "code",
       AUTHORIZATION_CODE);
-    Assertions.assertHasBodyParameter(
+    assertHasBodyParameter(
       defaultRequest,
       "grant_type",
       "authorization_code");
-    Assertions.assertHasBodyParameter(
+    assertHasBodyParameter(
       defaultRequest,
       "redirect_uri",
       SPOTIFY_API.getRedirectURI());
-    Assert.assertEquals(
+    assertEquals(
       "https://accounts.spotify.com:443/api/token",
       defaultRequest.getUri().toString());
-    Assertions.assertHasBodyParameter(
+    assertHasBodyParameter(
       defaultRequest,
       "client_id",
       SPOTIFY_API.getClientId());
-    Assertions.assertHasBodyParameter(
+    assertHasBodyParameter(
       defaultRequest,
       "code_verifier",
       CODE_VERIFIER);

--- a/src/test/java/se/michaelthelin/spotify/requests/authorization/authorization_code/pkce/AuthorizationCodePKCERequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/authorization/authorization_code/pkce/AuthorizationCodePKCERequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.authorization.authorization_code.pkce;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -10,7 +10,7 @@ import se.michaelthelin.spotify.model_objects.credentials.AuthorizationCodeCrede
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 

--- a/src/test/java/se/michaelthelin/spotify/requests/authorization/client_credentials/ClientCredentialsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/authorization/client_credentials/ClientCredentialsRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.authorization.client_credentials;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.credentials.ClientCredentials;
@@ -10,7 +10,7 @@ import se.michaelthelin.spotify.requests.authorization.AbstractAuthorizationTest
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 

--- a/src/test/java/se/michaelthelin/spotify/requests/authorization/client_credentials/ClientCredentialsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/authorization/client_credentials/ClientCredentialsRequestTest.java
@@ -1,9 +1,7 @@
 package se.michaelthelin.spotify.requests.authorization.client_credentials;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
-import se.michaelthelin.spotify.Assertions;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.credentials.ClientCredentials;
@@ -13,6 +11,8 @@ import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
+import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
+import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 public class ClientCredentialsRequestTest extends AbstractAuthorizationTest<ClientCredentials> {
   private final ClientCredentialsRequest defaultRequest = SPOTIFY_API.clientCredentials()
@@ -27,12 +27,12 @@ public class ClientCredentialsRequestTest extends AbstractAuthorizationTest<Clie
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assertions.assertHasHeader(defaultRequest, "Content-Type", "application/x-www-form-urlencoded");
-    Assertions.assertHasBodyParameter(
+    assertHasHeader(defaultRequest, "Content-Type", "application/x-www-form-urlencoded");
+    assertHasBodyParameter(
       defaultRequest,
       "grant_type",
       "client_credentials");
-    Assert.assertEquals(
+    assertEquals(
       "https://accounts.spotify.com:443/api/token",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/albums/GetAlbumRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/albums/GetAlbumRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.albums;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.AlbumType;
 import se.michaelthelin.spotify.enums.ModelObjectType;
@@ -17,7 +15,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.*;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetAlbumRequestTest extends AbstractDataTest<Album> {
   private final GetAlbumRequest defaultRequest = SPOTIFY_API.getAlbum(ID_ALBUM)
     .setHttpManager(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/albums/GetAlbumRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/albums/GetAlbumRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.albums;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.AlbumType;
 import se.michaelthelin.spotify.enums.ModelObjectType;
@@ -13,7 +13,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class GetAlbumRequestTest extends AbstractDataTest<Album> {
   private final GetAlbumRequest defaultRequest = SPOTIFY_API.getAlbum(ID_ALBUM)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/albums/GetAlbumsTracksRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/albums/GetAlbumsTracksRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.albums;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.specification.Paging;
@@ -16,7 +14,6 @@ import java.util.concurrent.ExecutionException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetAlbumsTracksRequestTest extends AbstractDataTest<Paging<TrackSimplified>> {
 
   private final GetAlbumsTracksRequest defaultRequest = SPOTIFY_API.getAlbumsTracks(ID_ALBUM)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/albums/GetAlbumsTracksRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/albums/GetAlbumsTracksRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.albums;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.specification.Paging;
@@ -11,8 +11,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class GetAlbumsTracksRequestTest extends AbstractDataTest<Paging<TrackSimplified>> {
 

--- a/src/test/java/se/michaelthelin/spotify/requests/data/albums/GetSeveralAlbumsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/albums/GetSeveralAlbumsRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.albums;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.specification.Album;
@@ -14,7 +12,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetSeveralAlbumsRequestTest extends AbstractDataTest<Album[]> {
 
   private final GetSeveralAlbumsRequest defaultRequest = SPOTIFY_API.getSeveralAlbums(ID_ALBUM, ID_ALBUM)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/albums/GetSeveralAlbumsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/albums/GetSeveralAlbumsRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.albums;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.specification.Album;
@@ -10,7 +10,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class GetSeveralAlbumsRequestTest extends AbstractDataTest<Album[]> {
 

--- a/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetArtistRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetArtistRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.artists;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.ModelObjectType;
@@ -17,7 +15,6 @@ import java.util.concurrent.ExecutionException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetArtistRequestTest extends AbstractDataTest<Artist> {
   private final GetArtistRequest defaultRequest = ITest.SPOTIFY_API.getArtist(ITest.ID_ARTIST)
     .setHttpManager(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetArtistRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetArtistRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.artists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -32,7 +31,7 @@ public class GetArtistRequestTest extends AbstractDataTest<Artist> {
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/artists/0LcJLqbBmaGUft1e9Mm8HV",
       defaultRequest.getUri().toString());
   }
@@ -71,7 +70,7 @@ public class GetArtistRequestTest extends AbstractDataTest<Artist> {
     assertEquals(
       59,
       (int) artist.getPopularity());
-    Assert.assertEquals(
+    assertEquals(
       ModelObjectType.ARTIST,
       artist.getType());
     assertEquals(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetArtistRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetArtistRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.artists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.ModelObjectType;
@@ -12,8 +12,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class GetArtistRequestTest extends AbstractDataTest<Artist> {
   private final GetArtistRequest defaultRequest = ITest.SPOTIFY_API.getArtist(ITest.ID_ARTIST)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetArtistsAlbumsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetArtistsAlbumsRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.artists;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.AlbumGroup;
@@ -19,7 +17,6 @@ import java.util.concurrent.ExecutionException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetArtistsAlbumsRequestTest extends AbstractDataTest<Paging<AlbumSimplified>> {
   private final GetArtistsAlbumsRequest defaultRequest = ITest.SPOTIFY_API.getArtistsAlbums(ITest.ID_ARTIST)
     .setHttpManager(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetArtistsAlbumsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetArtistsAlbumsRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.artists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.AlbumGroup;
@@ -14,8 +14,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class GetArtistsAlbumsRequestTest extends AbstractDataTest<Paging<AlbumSimplified>> {
   private final GetArtistsAlbumsRequest defaultRequest = ITest.SPOTIFY_API.getArtistsAlbums(ITest.ID_ARTIST)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetArtistsAlbumsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetArtistsAlbumsRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.artists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -38,7 +37,7 @@ public class GetArtistsAlbumsRequestTest extends AbstractDataTest<Paging<AlbumSi
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/artists/0LcJLqbBmaGUft1e9Mm8HV/albums?album_type=album&limit=10&market=SE&offset=0",
       defaultRequest.getUri().toString());
   }
@@ -60,10 +59,10 @@ public class GetArtistsAlbumsRequestTest extends AbstractDataTest<Paging<AlbumSi
     assertEquals(
       2,
       albumSimplifiedPaging.getItems().length);
-    Assert.assertEquals(
+    assertEquals(
       AlbumGroup.SINGLE,
       albumSimplifiedPaging.getItems()[0].getAlbumGroup());
-    Assert.assertEquals(
+    assertEquals(
       AlbumType.SINGLE,
       albumSimplifiedPaging.getItems()[0].getAlbumType());
     assertEquals(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetArtistsRelatedArtistsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetArtistsRelatedArtistsRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.artists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -11,7 +11,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class GetArtistsRelatedArtistsRequestTest extends AbstractDataTest<Artist[]> {
   private final GetArtistsRelatedArtistsRequest defaultRequest = ITest.SPOTIFY_API.getArtistsRelatedArtists(ITest.ID_ARTIST)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetArtistsRelatedArtistsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetArtistsRelatedArtistsRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.artists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -30,7 +29,7 @@ public class GetArtistsRelatedArtistsRequestTest extends AbstractDataTest<Artist
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/artists/0LcJLqbBmaGUft1e9Mm8HV/related-artists",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetArtistsRelatedArtistsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetArtistsRelatedArtistsRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.artists;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -15,7 +13,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetArtistsRelatedArtistsRequestTest extends AbstractDataTest<Artist[]> {
   private final GetArtistsRelatedArtistsRequest defaultRequest = ITest.SPOTIFY_API.getArtistsRelatedArtists(ITest.ID_ARTIST)
     .setHttpManager(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetArtistsTopTracksRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetArtistsTopTracksRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.artists;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -15,7 +13,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetArtistsTopTracksRequestTest extends AbstractDataTest<Track[]> {
   private final GetArtistsTopTracksRequest defaultRequest = ITest.SPOTIFY_API.getArtistsTopTracks(ITest.ID_ARTIST, ITest.COUNTRY)
     .setHttpManager(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetArtistsTopTracksRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetArtistsTopTracksRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.artists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -11,7 +11,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class GetArtistsTopTracksRequestTest extends AbstractDataTest<Track[]> {
   private final GetArtistsTopTracksRequest defaultRequest = ITest.SPOTIFY_API.getArtistsTopTracks(ITest.ID_ARTIST, ITest.COUNTRY)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetArtistsTopTracksRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetArtistsTopTracksRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.artists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -30,7 +29,7 @@ public class GetArtistsTopTracksRequestTest extends AbstractDataTest<Track[]> {
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/artists/0LcJLqbBmaGUft1e9Mm8HV/top-tracks?country=SE",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetSeveralArtistsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetSeveralArtistsRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.artists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -30,7 +29,7 @@ public class GetSeveralArtistsRequestTest extends AbstractDataTest<Artist[]> {
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/artists?ids=0LcJLqbBmaGUft1e9Mm8HV%2C0LcJLqbBmaGUft1e9Mm8HV",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetSeveralArtistsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetSeveralArtistsRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.artists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -11,7 +11,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class GetSeveralArtistsRequestTest extends AbstractDataTest<Artist[]> {
   private final GetSeveralArtistsRequest defaultRequest = ITest.SPOTIFY_API.getSeveralArtists(ITest.ID_ARTIST, ITest.ID_ARTIST)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetSeveralArtistsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetSeveralArtistsRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.artists;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -15,7 +13,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetSeveralArtistsRequestTest extends AbstractDataTest<Artist[]> {
   private final GetSeveralArtistsRequest defaultRequest = ITest.SPOTIFY_API.getSeveralArtists(ITest.ID_ARTIST, ITest.ID_ARTIST)
     .setHttpManager(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/browse/GetCategoryRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/browse/GetCategoryRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.browse;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.specification.Category;
@@ -10,7 +10,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class GetCategoryRequestTest extends AbstractDataTest<Category> {
   private final GetCategoryRequest defaultRequest = SPOTIFY_API.getCategory(CATEGORY_ID)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/browse/GetCategoryRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/browse/GetCategoryRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.browse;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.specification.Category;
@@ -14,7 +12,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetCategoryRequestTest extends AbstractDataTest<Category> {
   private final GetCategoryRequest defaultRequest = SPOTIFY_API.getCategory(CATEGORY_ID)
     .setHttpManager(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/browse/GetCategorysPlaylistRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/browse/GetCategorysPlaylistRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.browse;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.specification.Paging;
@@ -11,8 +11,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class GetCategorysPlaylistRequestTest extends AbstractDataTest<Paging<PlaylistSimplified>> {
   private final GetCategorysPlaylistsRequest defaultRequest = SPOTIFY_API.getCategorysPlaylists(CATEGORY_ID)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/browse/GetCategorysPlaylistRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/browse/GetCategorysPlaylistRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.browse;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.specification.Paging;
@@ -16,7 +14,6 @@ import java.util.concurrent.ExecutionException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetCategorysPlaylistRequestTest extends AbstractDataTest<Paging<PlaylistSimplified>> {
   private final GetCategorysPlaylistsRequest defaultRequest = SPOTIFY_API.getCategorysPlaylists(CATEGORY_ID)
     .setHttpManager(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/browse/GetListOfCategoriesRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/browse/GetListOfCategoriesRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.browse;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.specification.Category;
@@ -16,7 +14,6 @@ import java.util.concurrent.ExecutionException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetListOfCategoriesRequestTest extends AbstractDataTest<Paging<Category>> {
   private final GetListOfCategoriesRequest defaultRequest = SPOTIFY_API.getListOfCategories()
     .setHttpManager(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/browse/GetListOfCategoriesRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/browse/GetListOfCategoriesRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.browse;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.specification.Category;
@@ -11,8 +11,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class GetListOfCategoriesRequestTest extends AbstractDataTest<Paging<Category>> {
   private final GetListOfCategoriesRequest defaultRequest = SPOTIFY_API.getListOfCategories()

--- a/src/test/java/se/michaelthelin/spotify/requests/data/browse/GetListOfFeaturedPlaylistsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/browse/GetListOfFeaturedPlaylistsRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.browse;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.special.FeaturedPlaylists;
@@ -15,7 +13,6 @@ import java.util.concurrent.ExecutionException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetListOfFeaturedPlaylistsRequestTest extends AbstractDataTest<FeaturedPlaylists> {
   private final GetListOfFeaturedPlaylistsRequest defaultRequest = SPOTIFY_API.getListOfFeaturedPlaylists()
     .setHttpManager(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/browse/GetListOfFeaturedPlaylistsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/browse/GetListOfFeaturedPlaylistsRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.browse;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.special.FeaturedPlaylists;
@@ -10,8 +10,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class GetListOfFeaturedPlaylistsRequestTest extends AbstractDataTest<FeaturedPlaylists> {
   private final GetListOfFeaturedPlaylistsRequest defaultRequest = SPOTIFY_API.getListOfFeaturedPlaylists()

--- a/src/test/java/se/michaelthelin/spotify/requests/data/browse/GetListOfNewReleasesRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/browse/GetListOfNewReleasesRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.browse;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.specification.AlbumSimplified;
@@ -11,8 +11,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class GetListOfNewReleasesRequestTest extends AbstractDataTest<Paging<AlbumSimplified>> {
   private final GetListOfNewReleasesRequest defaultRequest = SPOTIFY_API.getListOfNewReleases()

--- a/src/test/java/se/michaelthelin/spotify/requests/data/browse/GetListOfNewReleasesRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/browse/GetListOfNewReleasesRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.browse;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.specification.AlbumSimplified;
@@ -16,7 +14,6 @@ import java.util.concurrent.ExecutionException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetListOfNewReleasesRequestTest extends AbstractDataTest<Paging<AlbumSimplified>> {
   private final GetListOfNewReleasesRequest defaultRequest = SPOTIFY_API.getListOfNewReleases()
     .setHttpManager(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/browse/GetRecommendationsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/browse/GetRecommendationsRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.browse;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.specification.Recommendations;
@@ -14,7 +12,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetRecommendationsRequestTest extends AbstractDataTest<Recommendations> {
   private final GetRecommendationsRequest defaultRequest = SPOTIFY_API.getRecommendations()
     .setHttpManager(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/browse/GetRecommendationsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/browse/GetRecommendationsRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.browse;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.specification.Recommendations;
@@ -10,7 +10,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class GetRecommendationsRequestTest extends AbstractDataTest<Recommendations> {
   private final GetRecommendationsRequest defaultRequest = SPOTIFY_API.getRecommendations()

--- a/src/test/java/se/michaelthelin/spotify/requests/data/browse/miscellaneous/GetAvailableGenreSeedsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/browse/miscellaneous/GetAvailableGenreSeedsRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.browse.miscellaneous;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.requests.data.AbstractDataTest;
@@ -9,7 +9,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class GetAvailableGenreSeedsRequestTest extends AbstractDataTest<String[]> {
   private final GetAvailableGenreSeedsRequest defaultRequest = SPOTIFY_API.getAvailableGenreSeeds()

--- a/src/test/java/se/michaelthelin/spotify/requests/data/browse/miscellaneous/GetAvailableGenreSeedsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/browse/miscellaneous/GetAvailableGenreSeedsRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.browse.miscellaneous;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.requests.data.AbstractDataTest;
@@ -13,7 +11,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetAvailableGenreSeedsRequestTest extends AbstractDataTest<String[]> {
   private final GetAvailableGenreSeedsRequest defaultRequest = SPOTIFY_API.getAvailableGenreSeeds()
     .setHttpManager(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/episodes/GetEpisodeRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/episodes/GetEpisodeRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.episodes;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.ModelObjectType;
@@ -17,7 +15,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.*;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetEpisodeRequestTest extends AbstractDataTest<Episode> {
   private final GetEpisodeRequest defaultRequest = ITest.SPOTIFY_API
     .getEpisode(ITest.ID_EPISODE)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/episodes/GetEpisodeRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/episodes/GetEpisodeRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.episodes;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -34,7 +33,7 @@ public class GetEpisodeRequestTest extends AbstractDataTest<Episode> {
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/episodes/4GI3dxEafwap1sFiTGPKd1?market=SE",
       defaultRequest.getUri().toString());
   }
@@ -66,7 +65,7 @@ public class GetEpisodeRequestTest extends AbstractDataTest<Episode> {
     assertEquals(
       "https://api.spotify.com/v1/episodes/4GI3dxEafwap1sFiTGPKd1",
       episode.getHref());
-    Assert.assertEquals(
+    assertEquals(
       ITest.ID_EPISODE,
       episode.getId());
     assertEquals(
@@ -85,7 +84,7 @@ public class GetEpisodeRequestTest extends AbstractDataTest<Episode> {
     assertEquals(
       "2015-05-22",
       episode.getReleaseDate());
-    Assert.assertEquals(
+    assertEquals(
       ReleaseDatePrecision.DAY,
       episode.getReleaseDatePrecision());
     assertFalse(
@@ -97,7 +96,7 @@ public class GetEpisodeRequestTest extends AbstractDataTest<Episode> {
       episode.getResumePoint().getFullyPlayed());
     assertNotNull(
       episode.getShow());
-    Assert.assertEquals(
+    assertEquals(
       ModelObjectType.EPISODE,
       episode.getType());
     assertEquals(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/episodes/GetEpisodeRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/episodes/GetEpisodeRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.episodes;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.ModelObjectType;
@@ -13,7 +13,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class GetEpisodeRequestTest extends AbstractDataTest<Episode> {
   private final GetEpisodeRequest defaultRequest = ITest.SPOTIFY_API

--- a/src/test/java/se/michaelthelin/spotify/requests/data/episodes/GetSeveralEpisodesRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/episodes/GetSeveralEpisodesRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.episodes;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -11,7 +11,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class GetSeveralEpisodesRequestTest extends AbstractDataTest<Episode[]> {
   private final GetSeveralEpisodesRequest defaultRequest = ITest.SPOTIFY_API

--- a/src/test/java/se/michaelthelin/spotify/requests/data/episodes/GetSeveralEpisodesRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/episodes/GetSeveralEpisodesRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.episodes;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -32,7 +31,7 @@ public class GetSeveralEpisodesRequestTest extends AbstractDataTest<Episode[]> {
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/episodes?ids=4GI3dxEafwap1sFiTGPKd1%2C4GI3dxEafwap1sFiTGPKd1&market=SE",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/episodes/GetSeveralEpisodesRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/episodes/GetSeveralEpisodesRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.episodes;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -15,7 +13,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetSeveralEpisodesRequestTest extends AbstractDataTest<Episode[]> {
   private final GetSeveralEpisodesRequest defaultRequest = ITest.SPOTIFY_API
     .getSeveralEpisodes(ITest.ID_EPISODE, ITest.ID_EPISODE)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/follow/CheckCurrentUserFollowsArtistsOrUsersRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/follow/CheckCurrentUserFollowsArtistsOrUsersRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.follow;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.ModelObjectType;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -10,7 +10,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CheckCurrentUserFollowsArtistsOrUsersRequestTest extends AbstractDataTest<Boolean[]> {
   private final CheckCurrentUserFollowsArtistsOrUsersRequest defaultRequest = SPOTIFY_API

--- a/src/test/java/se/michaelthelin/spotify/requests/data/follow/CheckCurrentUserFollowsArtistsOrUsersRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/follow/CheckCurrentUserFollowsArtistsOrUsersRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.follow;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.ModelObjectType;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -14,7 +12,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(MockitoJUnitRunner.class)
 public class CheckCurrentUserFollowsArtistsOrUsersRequestTest extends AbstractDataTest<Boolean[]> {
   private final CheckCurrentUserFollowsArtistsOrUsersRequest defaultRequest = SPOTIFY_API
     .checkCurrentUserFollowsArtistsOrUsers(ModelObjectType.ARTIST, new String[]{ID_ARTIST, ID_ARTIST})

--- a/src/test/java/se/michaelthelin/spotify/requests/data/follow/CheckUsersFollowPlaylistRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/follow/CheckUsersFollowPlaylistRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.follow;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.requests.data.AbstractDataTest;
@@ -13,7 +11,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(MockitoJUnitRunner.class)
 public class CheckUsersFollowPlaylistRequestTest extends AbstractDataTest<Boolean[]> {
   private final CheckUsersFollowPlaylistRequest defaultRequest = SPOTIFY_API
     .checkUsersFollowPlaylist(ID_USER, ID_PLAYLIST, new String[]{ID_USER, ID_USER})

--- a/src/test/java/se/michaelthelin/spotify/requests/data/follow/CheckUsersFollowPlaylistRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/follow/CheckUsersFollowPlaylistRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.follow;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.requests.data.AbstractDataTest;
@@ -9,7 +9,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CheckUsersFollowPlaylistRequestTest extends AbstractDataTest<Boolean[]> {
   private final CheckUsersFollowPlaylistRequest defaultRequest = SPOTIFY_API

--- a/src/test/java/se/michaelthelin/spotify/requests/data/follow/FollowArtistsOrUsersRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/follow/FollowArtistsOrUsersRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.follow;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.ModelObjectType;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -17,7 +15,6 @@ import static org.junit.Assert.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
-@RunWith(MockitoJUnitRunner.class)
 public class FollowArtistsOrUsersRequestTest extends AbstractDataTest<String> {
   private final FollowArtistsOrUsersRequest defaultRequest = SPOTIFY_API
     .followArtistsOrUsers(ModelObjectType.ARTIST, new String[]{ID_ARTIST, ID_ARTIST})

--- a/src/test/java/se/michaelthelin/spotify/requests/data/follow/FollowArtistsOrUsersRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/follow/FollowArtistsOrUsersRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.follow;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.ModelObjectType;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -10,8 +10,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 

--- a/src/test/java/se/michaelthelin/spotify/requests/data/follow/FollowPlaylistRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/follow/FollowPlaylistRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.follow;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.requests.data.AbstractDataTest;
@@ -16,7 +14,6 @@ import static org.junit.Assert.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
-@RunWith(MockitoJUnitRunner.class)
 public class FollowPlaylistRequestTest extends AbstractDataTest<String> {
   private final FollowPlaylistRequest defaultRequest = SPOTIFY_API
     .followPlaylist(ID_PLAYLIST, PUBLIC)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/follow/FollowPlaylistRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/follow/FollowPlaylistRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.follow;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.requests.data.AbstractDataTest;
@@ -9,8 +9,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 

--- a/src/test/java/se/michaelthelin/spotify/requests/data/follow/GetUsersFollowedArtistsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/follow/GetUsersFollowedArtistsRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.follow;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.specification.Artist;
@@ -15,7 +13,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.*;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetUsersFollowedArtistsRequestTest extends AbstractDataTest<PagingCursorbased<Artist>> {
   private final GetUsersFollowedArtistsRequest defaultRequest = SPOTIFY_API.getUsersFollowedArtists(TYPE)
     .setHttpManager(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/follow/GetUsersFollowedArtistsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/follow/GetUsersFollowedArtistsRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.follow;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.specification.Artist;
@@ -11,7 +11,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class GetUsersFollowedArtistsRequestTest extends AbstractDataTest<PagingCursorbased<Artist>> {
   private final GetUsersFollowedArtistsRequest defaultRequest = SPOTIFY_API.getUsersFollowedArtists(TYPE)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/follow/UnfollowArtistsOrUsersRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/follow/UnfollowArtistsOrUsersRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.follow;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.ModelObjectType;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -17,7 +15,6 @@ import static org.junit.Assert.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
-@RunWith(MockitoJUnitRunner.class)
 public class UnfollowArtistsOrUsersRequestTest extends AbstractDataTest<String> {
   private final UnfollowArtistsOrUsersRequest defaultRequest = SPOTIFY_API
     .unfollowArtistsOrUsers(ModelObjectType.ARTIST, new String[]{ID_ARTIST, ID_ARTIST})

--- a/src/test/java/se/michaelthelin/spotify/requests/data/follow/UnfollowArtistsOrUsersRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/follow/UnfollowArtistsOrUsersRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.follow;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.ModelObjectType;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -10,8 +10,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 

--- a/src/test/java/se/michaelthelin/spotify/requests/data/follow/UnfollowPlaylistRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/follow/UnfollowPlaylistRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.follow;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -10,8 +10,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class UnfollowPlaylistRequestTest extends AbstractDataTest<String> {
   private final UnfollowPlaylistRequest defaultRequest = ITest.SPOTIFY_API

--- a/src/test/java/se/michaelthelin/spotify/requests/data/follow/UnfollowPlaylistRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/follow/UnfollowPlaylistRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.follow;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -13,6 +12,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -29,7 +29,7 @@ public class UnfollowPlaylistRequestTest extends AbstractDataTest<String> {
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/playlists/3AGOiaoRXMSjswCLtuNqv5/followers",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/follow/UnfollowPlaylistRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/follow/UnfollowPlaylistRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.follow;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -15,7 +13,6 @@ import java.util.concurrent.ExecutionException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-@RunWith(MockitoJUnitRunner.class)
 public class UnfollowPlaylistRequestTest extends AbstractDataTest<String> {
   private final UnfollowPlaylistRequest defaultRequest = ITest.SPOTIFY_API
     .unfollowPlaylist(ITest.ID_PLAYLIST)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/follow/legacy/FollowPlaylistRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/follow/legacy/FollowPlaylistRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.follow.legacy;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -10,8 +10,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 

--- a/src/test/java/se/michaelthelin/spotify/requests/data/follow/legacy/FollowPlaylistRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/follow/legacy/FollowPlaylistRequestTest.java
@@ -1,11 +1,9 @@
 package se.michaelthelin.spotify.requests.data.follow.legacy;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
-import se.michaelthelin.spotify.Assertions;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -14,7 +12,10 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
+import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FollowPlaylistRequestTest extends AbstractDataTest<String> {
@@ -30,12 +31,12 @@ public class FollowPlaylistRequestTest extends AbstractDataTest<String> {
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assertions.assertHasHeader(defaultRequest, "Content-Type", "application/json");
-    Assertions.assertHasBodyParameter(
+    assertHasHeader(defaultRequest, "Content-Type", "application/json");
+    assertHasBodyParameter(
       defaultRequest,
       "public",
       ITest.PUBLIC);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/users/abbaspotify/playlists/3AGOiaoRXMSjswCLtuNqv5/followers",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/follow/legacy/FollowPlaylistRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/follow/legacy/FollowPlaylistRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.follow.legacy;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -17,7 +15,6 @@ import static org.junit.Assert.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
-@RunWith(MockitoJUnitRunner.class)
 public class FollowPlaylistRequestTest extends AbstractDataTest<String> {
   private final FollowPlaylistRequest defaultRequest = ITest.SPOTIFY_API
     .followPlaylist(ITest.ID_USER, ITest.ID_PLAYLIST, ITest.PUBLIC)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/follow/legacy/UnfollowPlaylistRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/follow/legacy/UnfollowPlaylistRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.follow.legacy;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -13,6 +12,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -29,7 +29,7 @@ public class UnfollowPlaylistRequestTest extends AbstractDataTest<String> {
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/users/abbaspotify/playlists/3AGOiaoRXMSjswCLtuNqv5/followers",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/follow/legacy/UnfollowPlaylistRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/follow/legacy/UnfollowPlaylistRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.follow.legacy;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -15,7 +13,6 @@ import java.util.concurrent.ExecutionException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-@RunWith(MockitoJUnitRunner.class)
 public class UnfollowPlaylistRequestTest extends AbstractDataTest<String> {
   private final UnfollowPlaylistRequest defaultRequest = ITest.SPOTIFY_API
     .unfollowPlaylist(ITest.ID_USER, ITest.ID_PLAYLIST)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/follow/legacy/UnfollowPlaylistRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/follow/legacy/UnfollowPlaylistRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.follow.legacy;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -10,8 +10,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class UnfollowPlaylistRequestTest extends AbstractDataTest<String> {
   private final UnfollowPlaylistRequest defaultRequest = ITest.SPOTIFY_API

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/CheckUsersSavedAlbumsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/CheckUsersSavedAlbumsRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -29,7 +28,7 @@ public class CheckUsersSavedAlbumsRequestTest extends AbstractDataTest<Boolean[]
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/me/albums/contains?ids=5zT1JLIj9E57p3e1rFm9Uq%2C5zT1JLIj9E57p3e1rFm9Uq",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/CheckUsersSavedAlbumsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/CheckUsersSavedAlbumsRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -10,7 +10,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CheckUsersSavedAlbumsRequestTest extends AbstractDataTest<Boolean[]> {
   private final CheckUsersSavedAlbumsRequest defaultRequest = ITest.SPOTIFY_API.checkUsersSavedAlbums(ITest.ID_ALBUM, ITest.ID_ALBUM)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/CheckUsersSavedAlbumsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/CheckUsersSavedAlbumsRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -14,7 +12,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(MockitoJUnitRunner.class)
 public class CheckUsersSavedAlbumsRequestTest extends AbstractDataTest<Boolean[]> {
   private final CheckUsersSavedAlbumsRequest defaultRequest = ITest.SPOTIFY_API.checkUsersSavedAlbums(ITest.ID_ALBUM, ITest.ID_ALBUM)
     .setHttpManager(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/CheckUsersSavedShowsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/CheckUsersSavedShowsRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -14,7 +12,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(MockitoJUnitRunner.class)
 public class CheckUsersSavedShowsRequestTest extends AbstractDataTest<Boolean[]> {
   private final CheckUsersSavedShowsRequest defaultRequest = ITest.SPOTIFY_API.checkUsersSavedShows(ITest.ID_SHOW, ITest.ID_SHOW)
     .setHttpManager(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/CheckUsersSavedShowsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/CheckUsersSavedShowsRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -29,7 +28,7 @@ public class CheckUsersSavedShowsRequestTest extends AbstractDataTest<Boolean[]>
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/me/shows/contains?ids=5AvwZVawapvyhJUIx71pdJ%2C5AvwZVawapvyhJUIx71pdJ",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/CheckUsersSavedShowsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/CheckUsersSavedShowsRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -10,7 +10,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CheckUsersSavedShowsRequestTest extends AbstractDataTest<Boolean[]> {
   private final CheckUsersSavedShowsRequest defaultRequest = ITest.SPOTIFY_API.checkUsersSavedShows(ITest.ID_SHOW, ITest.ID_SHOW)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/CheckUsersSavedTracksRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/CheckUsersSavedTracksRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -14,7 +12,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(MockitoJUnitRunner.class)
 public class CheckUsersSavedTracksRequestTest extends AbstractDataTest<Boolean[]> {
   private final CheckUsersSavedTracksRequest defaultRequest = ITest.SPOTIFY_API.checkUsersSavedTracks(ITest.ID_TRACK, ITest.ID_TRACK)
     .setHttpManager(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/CheckUsersSavedTracksRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/CheckUsersSavedTracksRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -10,7 +10,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CheckUsersSavedTracksRequestTest extends AbstractDataTest<Boolean[]> {
   private final CheckUsersSavedTracksRequest defaultRequest = ITest.SPOTIFY_API.checkUsersSavedTracks(ITest.ID_TRACK, ITest.ID_TRACK)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/CheckUsersSavedTracksRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/CheckUsersSavedTracksRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -29,7 +28,7 @@ public class CheckUsersSavedTracksRequestTest extends AbstractDataTest<Boolean[]
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/me/tracks/contains?ids=01iyCAUm8EvOFqVWYJ3dVX%2C01iyCAUm8EvOFqVWYJ3dVX",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/GetCurrentUsersSavedAlbumsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/GetCurrentUsersSavedAlbumsRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -17,7 +15,6 @@ import java.util.concurrent.ExecutionException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetCurrentUsersSavedAlbumsRequestTest extends AbstractDataTest<Paging<SavedAlbum>> {
   private final GetCurrentUsersSavedAlbumsRequest defaultRequest = ITest.SPOTIFY_API.getCurrentUsersSavedAlbums()
     .setHttpManager(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/GetCurrentUsersSavedAlbumsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/GetCurrentUsersSavedAlbumsRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -12,8 +12,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class GetCurrentUsersSavedAlbumsRequestTest extends AbstractDataTest<Paging<SavedAlbum>> {
   private final GetCurrentUsersSavedAlbumsRequest defaultRequest = ITest.SPOTIFY_API.getCurrentUsersSavedAlbums()

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/GetCurrentUsersSavedAlbumsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/GetCurrentUsersSavedAlbumsRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -35,7 +34,7 @@ public class GetCurrentUsersSavedAlbumsRequestTest extends AbstractDataTest<Pagi
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/me/albums?limit=10&market=SE&offset=0",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/GetUsersSavedShowsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/GetUsersSavedShowsRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -17,7 +15,6 @@ import java.util.concurrent.ExecutionException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetUsersSavedShowsRequestTest extends AbstractDataTest<Paging<SavedShow>> {
   private final GetUsersSavedShowsRequest defaultRequest = ITest.SPOTIFY_API.getUsersSavedShows()
     .setHttpManager(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/GetUsersSavedShowsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/GetUsersSavedShowsRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -34,7 +33,7 @@ public class GetUsersSavedShowsRequestTest extends AbstractDataTest<Paging<Saved
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/me/shows?limit=10&offset=0",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/GetUsersSavedShowsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/GetUsersSavedShowsRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -12,8 +12,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class GetUsersSavedShowsRequestTest extends AbstractDataTest<Paging<SavedShow>> {
   private final GetUsersSavedShowsRequest defaultRequest = ITest.SPOTIFY_API.getUsersSavedShows()

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/GetUsersSavedTracksRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/GetUsersSavedTracksRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -35,7 +34,7 @@ public class GetUsersSavedTracksRequestTest extends AbstractDataTest<Paging<Save
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/me/tracks?limit=10&market=SE&offset=0",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/GetUsersSavedTracksRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/GetUsersSavedTracksRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -17,7 +15,6 @@ import java.util.concurrent.ExecutionException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetUsersSavedTracksRequestTest extends AbstractDataTest<Paging<SavedTrack>> {
   private final GetUsersSavedTracksRequest defaultRequest = ITest.SPOTIFY_API.getUsersSavedTracks()
     .setHttpManager(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/GetUsersSavedTracksRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/GetUsersSavedTracksRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -12,8 +12,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class GetUsersSavedTracksRequestTest extends AbstractDataTest<Paging<SavedTrack>> {
   private final GetUsersSavedTracksRequest defaultRequest = ITest.SPOTIFY_API.getUsersSavedTracks()

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/RemoveAlbumsForCurrentUserRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/RemoveAlbumsForCurrentUserRequestTest.java
@@ -1,11 +1,9 @@
 package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
-import se.michaelthelin.spotify.Assertions;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -14,7 +12,10 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
+import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RemoveAlbumsForCurrentUserRequestTest extends AbstractDataTest<String> {
@@ -35,16 +36,16 @@ public class RemoveAlbumsForCurrentUserRequestTest extends AbstractDataTest<Stri
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/me/albums?ids=5zT1JLIj9E57p3e1rFm9Uq%2C5zT1JLIj9E57p3e1rFm9Uq",
       defaultRequest.getUri().toString());
 
     assertHasAuthorizationHeader(bodyRequest);
-    Assertions.assertHasHeader(defaultRequest, "Content-Type", "application/json");
-    Assertions.assertHasBodyParameter(bodyRequest,
+    assertHasHeader(defaultRequest, "Content-Type", "application/json");
+    assertHasBodyParameter(bodyRequest,
       "ids",
       ITest.ALBUMS);
-    Assert.assertEquals("https://api.spotify.com:443/v1/me/albums",
+    assertEquals("https://api.spotify.com:443/v1/me/albums",
       bodyRequest.getUri().toString());
   }
 

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/RemoveAlbumsForCurrentUserRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/RemoveAlbumsForCurrentUserRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -17,7 +15,6 @@ import static org.junit.Assert.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
-@RunWith(MockitoJUnitRunner.class)
 public class RemoveAlbumsForCurrentUserRequestTest extends AbstractDataTest<String> {
   private final RemoveAlbumsForCurrentUserRequest defaultRequest = ITest.SPOTIFY_API
     .removeAlbumsForCurrentUser(ITest.ID_ALBUM, ITest.ID_ALBUM)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/RemoveAlbumsForCurrentUserRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/RemoveAlbumsForCurrentUserRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -10,8 +10,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/RemoveUsersSavedShowsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/RemoveUsersSavedShowsRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -17,7 +15,6 @@ import static org.junit.Assert.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
-@RunWith(MockitoJUnitRunner.class)
 public class RemoveUsersSavedShowsRequestTest extends AbstractDataTest<String> {
   private final RemoveUsersSavedShowsRequest defaultRequest = ITest.SPOTIFY_API
     .removeUsersSavedShows(ITest.ID_SHOW, ITest.ID_SHOW)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/RemoveUsersSavedShowsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/RemoveUsersSavedShowsRequestTest.java
@@ -1,11 +1,9 @@
 package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
-import se.michaelthelin.spotify.Assertions;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -14,7 +12,10 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
+import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RemoveUsersSavedShowsRequestTest extends AbstractDataTest<String> {
@@ -37,16 +38,16 @@ public class RemoveUsersSavedShowsRequestTest extends AbstractDataTest<String> {
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/me/shows?ids=5AvwZVawapvyhJUIx71pdJ%2C5AvwZVawapvyhJUIx71pdJ&market=SE",
       defaultRequest.getUri().toString());
 
     assertHasAuthorizationHeader(bodyRequest);
-    Assertions.assertHasHeader(defaultRequest, "Content-Type", "application/json");
-    Assertions.assertHasBodyParameter(bodyRequest,
+    assertHasHeader(defaultRequest, "Content-Type", "application/json");
+    assertHasBodyParameter(bodyRequest,
       "ids",
       ITest.SHOWS);
-    Assert.assertEquals("https://api.spotify.com:443/v1/me/shows?market=SE",
+    assertEquals("https://api.spotify.com:443/v1/me/shows?market=SE",
       bodyRequest.getUri().toString());
   }
 

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/RemoveUsersSavedShowsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/RemoveUsersSavedShowsRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -10,8 +10,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/RemoveUsersSavedTracksRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/RemoveUsersSavedTracksRequestTest.java
@@ -1,11 +1,9 @@
 package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
-import se.michaelthelin.spotify.Assertions;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -14,7 +12,10 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
+import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RemoveUsersSavedTracksRequestTest extends AbstractDataTest<String> {
@@ -35,16 +36,16 @@ public class RemoveUsersSavedTracksRequestTest extends AbstractDataTest<String> 
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/me/tracks?ids=01iyCAUm8EvOFqVWYJ3dVX%2C01iyCAUm8EvOFqVWYJ3dVX",
       defaultRequest.getUri().toString());
 
     assertHasAuthorizationHeader(bodyRequest);
-    Assertions.assertHasHeader(defaultRequest, "Content-Type", "application/json");
-    Assertions.assertHasBodyParameter(bodyRequest,
+    assertHasHeader(defaultRequest, "Content-Type", "application/json");
+    assertHasBodyParameter(bodyRequest,
       "ids",
       ITest.TRACKS);
-    Assert.assertEquals("https://api.spotify.com:443/v1/me/tracks",
+    assertEquals("https://api.spotify.com:443/v1/me/tracks",
       bodyRequest.getUri().toString());
   }
 

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/RemoveUsersSavedTracksRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/RemoveUsersSavedTracksRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -17,7 +15,6 @@ import static org.junit.Assert.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
-@RunWith(MockitoJUnitRunner.class)
 public class RemoveUsersSavedTracksRequestTest extends AbstractDataTest<String> {
   private final RemoveUsersSavedTracksRequest defaultRequest = ITest.SPOTIFY_API
     .removeUsersSavedTracks(ITest.ID_TRACK, ITest.ID_TRACK)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/RemoveUsersSavedTracksRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/RemoveUsersSavedTracksRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -10,8 +10,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/SaveAlbumsForCurrentUserRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/SaveAlbumsForCurrentUserRequestTest.java
@@ -1,11 +1,9 @@
 package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
-import se.michaelthelin.spotify.Assertions;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -14,7 +12,10 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
+import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SaveAlbumsForCurrentUserRequestTest extends AbstractDataTest<String> {
@@ -35,17 +36,17 @@ public class SaveAlbumsForCurrentUserRequestTest extends AbstractDataTest<String
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/me/albums?ids=5zT1JLIj9E57p3e1rFm9Uq%2C5zT1JLIj9E57p3e1rFm9Uq",
       defaultRequest.getUri().toString());
 
     assertHasAuthorizationHeader(bodyRequest);
-    Assertions.assertHasHeader(defaultRequest, "Content-Type", "application/json");
-    Assertions.assertHasBodyParameter(
+    assertHasHeader(defaultRequest, "Content-Type", "application/json");
+    assertHasBodyParameter(
       bodyRequest,
       "ids",
       ITest.ALBUMS);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/me/albums",
       bodyRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/SaveAlbumsForCurrentUserRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/SaveAlbumsForCurrentUserRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -17,7 +15,6 @@ import static org.junit.Assert.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SaveAlbumsForCurrentUserRequestTest extends AbstractDataTest<String> {
   private final SaveAlbumsForCurrentUserRequest defaultRequest = ITest.SPOTIFY_API
     .saveAlbumsForCurrentUser(ITest.ID_ALBUM, ITest.ID_ALBUM)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/SaveAlbumsForCurrentUserRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/SaveAlbumsForCurrentUserRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -10,8 +10,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/SaveShowsForCurrentUserRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/SaveShowsForCurrentUserRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -17,7 +15,6 @@ import static org.junit.Assert.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SaveShowsForCurrentUserRequestTest extends AbstractDataTest<String> {
   private final SaveShowsForCurrentUserRequest defaultRequest = ITest.SPOTIFY_API
     .saveShowsForCurrentUser(ITest.ID_SHOW, ITest.ID_SHOW)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/SaveShowsForCurrentUserRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/SaveShowsForCurrentUserRequestTest.java
@@ -1,11 +1,9 @@
 package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
-import se.michaelthelin.spotify.Assertions;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -14,7 +12,10 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
+import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SaveShowsForCurrentUserRequestTest extends AbstractDataTest<String> {
@@ -35,16 +36,16 @@ public class SaveShowsForCurrentUserRequestTest extends AbstractDataTest<String>
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/me/shows?ids=5AvwZVawapvyhJUIx71pdJ%2C5AvwZVawapvyhJUIx71pdJ",
       defaultRequest.getUri().toString());
 
     assertHasAuthorizationHeader(bodyRequest);
-    Assertions.assertHasHeader(defaultRequest, "Content-Type", "application/json");
-    Assertions.assertHasBodyParameter(bodyRequest,
+    assertHasHeader(defaultRequest, "Content-Type", "application/json");
+    assertHasBodyParameter(bodyRequest,
       "ids",
       ITest.SHOWS);
-    Assert.assertEquals("https://api.spotify.com:443/v1/me/shows",
+    assertEquals("https://api.spotify.com:443/v1/me/shows",
       bodyRequest.getUri().toString());
   }
 

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/SaveShowsForCurrentUserRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/SaveShowsForCurrentUserRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -10,8 +10,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/SaveTracksForUserRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/SaveTracksForUserRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -17,7 +15,6 @@ import static org.junit.Assert.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SaveTracksForUserRequestTest extends AbstractDataTest<String> {
   private final SaveTracksForUserRequest defaultRequest = ITest.SPOTIFY_API
     .saveTracksForUser(ITest.ID_TRACK, ITest.ID_TRACK)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/SaveTracksForUserRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/SaveTracksForUserRequestTest.java
@@ -1,11 +1,9 @@
 package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
-import se.michaelthelin.spotify.Assertions;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -14,7 +12,10 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
+import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SaveTracksForUserRequestTest extends AbstractDataTest<String> {
@@ -35,17 +36,17 @@ public class SaveTracksForUserRequestTest extends AbstractDataTest<String> {
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/me/tracks?ids=01iyCAUm8EvOFqVWYJ3dVX%2C01iyCAUm8EvOFqVWYJ3dVX",
       defaultRequest.getUri().toString());
 
     assertHasAuthorizationHeader(bodyRequest);
-    Assertions.assertHasHeader(defaultRequest, "Content-Type", "application/json");
-    Assertions.assertHasBodyParameter(
+    assertHasHeader(defaultRequest, "Content-Type", "application/json");
+    assertHasBodyParameter(
       bodyRequest,
       "ids",
       ITest.TRACKS);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/me/tracks",
       bodyRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/SaveTracksForUserRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/SaveTracksForUserRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.library;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -10,8 +10,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 

--- a/src/test/java/se/michaelthelin/spotify/requests/data/personalization/simplified/GetUsersTopArtistsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/personalization/simplified/GetUsersTopArtistsRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.personalization.simplified;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -12,8 +12,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class GetUsersTopArtistsRequestTest extends AbstractDataTest<Paging<Artist>> {
   private final GetUsersTopArtistsRequest defaultRequest = ITest.SPOTIFY_API.getUsersTopArtists()

--- a/src/test/java/se/michaelthelin/spotify/requests/data/personalization/simplified/GetUsersTopArtistsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/personalization/simplified/GetUsersTopArtistsRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.personalization.simplified;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -35,7 +34,7 @@ public class GetUsersTopArtistsRequestTest extends AbstractDataTest<Paging<Artis
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/me/top/artists?limit=10&offset=0&time_range=medium_term",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/personalization/simplified/GetUsersTopArtistsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/personalization/simplified/GetUsersTopArtistsRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.personalization.simplified;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -17,7 +15,6 @@ import java.util.concurrent.ExecutionException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetUsersTopArtistsRequestTest extends AbstractDataTest<Paging<Artist>> {
   private final GetUsersTopArtistsRequest defaultRequest = ITest.SPOTIFY_API.getUsersTopArtists()
     .setHttpManager(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/personalization/simplified/GetUsersTopTracksRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/personalization/simplified/GetUsersTopTracksRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.personalization.simplified;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -12,8 +12,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class GetUsersTopTracksRequestTest extends AbstractDataTest<Paging<Track>> {
   private final GetUsersTopTracksRequest defaultRequest = ITest.SPOTIFY_API.getUsersTopTracks()

--- a/src/test/java/se/michaelthelin/spotify/requests/data/personalization/simplified/GetUsersTopTracksRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/personalization/simplified/GetUsersTopTracksRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.personalization.simplified;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -17,7 +15,6 @@ import java.util.concurrent.ExecutionException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetUsersTopTracksRequestTest extends AbstractDataTest<Paging<Track>> {
   private final GetUsersTopTracksRequest defaultRequest = ITest.SPOTIFY_API.getUsersTopTracks()
     .setHttpManager(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/personalization/simplified/GetUsersTopTracksRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/personalization/simplified/GetUsersTopTracksRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.personalization.simplified;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -35,7 +34,7 @@ public class GetUsersTopTracksRequestTest extends AbstractDataTest<Paging<Track>
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/me/top/tracks?limit=10&offset=0&time_range=medium_term",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/AddItemToUsersPlaybackQueueRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/AddItemToUsersPlaybackQueueRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -16,7 +14,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
-@RunWith(MockitoJUnitRunner.class)
 public class AddItemToUsersPlaybackQueueRequestTest extends AbstractDataTest<String> {
   private final AddItemToUsersPlaybackQueueRequest defaultRequest = ITest.SPOTIFY_API
     .addItemToUsersPlaybackQueue("spotify:track:" + ITest.ID_TRACK)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/AddItemToUsersPlaybackQueueRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/AddItemToUsersPlaybackQueueRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -10,8 +10,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 public class AddItemToUsersPlaybackQueueRequestTest extends AbstractDataTest<String> {

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/AddItemToUsersPlaybackQueueRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/AddItemToUsersPlaybackQueueRequestTest.java
@@ -1,11 +1,9 @@
 package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
-import se.michaelthelin.spotify.Assertions;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -14,7 +12,9 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AddItemToUsersPlaybackQueueRequestTest extends AbstractDataTest<String> {
@@ -30,8 +30,8 @@ public class AddItemToUsersPlaybackQueueRequestTest extends AbstractDataTest<Str
 
   @Test
   public void shouldComplyWithReference() {
-    Assertions.assertHasHeader(defaultRequest, "Content-Type", "application/json");
-    Assert.assertEquals("https://api.spotify.com:443/v1/me/player/queue?uri=spotify%3Atrack%3A01iyCAUm8EvOFqVWYJ3dVX&device_id=5fbb3ba6aa454b5534c4ba43a8c7e8e45a63ad0e",
+    assertHasHeader(defaultRequest, "Content-Type", "application/json");
+    assertEquals("https://api.spotify.com:443/v1/me/player/queue?uri=spotify%3Atrack%3A01iyCAUm8EvOFqVWYJ3dVX&device_id=5fbb3ba6aa454b5534c4ba43a8c7e8e45a63ad0e",
       defaultRequest.getUri().toString());
   }
 

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/GetCurrentUsersRecentlyPlayedTracksRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/GetCurrentUsersRecentlyPlayedTracksRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -36,7 +35,7 @@ public class GetCurrentUsersRecentlyPlayedTracksRequestTest extends AbstractData
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/me/player/recently-played?after=2018-01-27T21%3A07%3A10&before=2016-01-27T22%3A07%3A00&limit=10",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/GetCurrentUsersRecentlyPlayedTracksRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/GetCurrentUsersRecentlyPlayedTracksRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -12,8 +12,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class GetCurrentUsersRecentlyPlayedTracksRequestTest extends AbstractDataTest<PagingCursorbased<PlayHistory>> {
   private final GetCurrentUsersRecentlyPlayedTracksRequest defaultRequest = ITest.SPOTIFY_API

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/GetCurrentUsersRecentlyPlayedTracksRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/GetCurrentUsersRecentlyPlayedTracksRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -17,7 +15,6 @@ import java.util.concurrent.ExecutionException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetCurrentUsersRecentlyPlayedTracksRequestTest extends AbstractDataTest<PagingCursorbased<PlayHistory>> {
   private final GetCurrentUsersRecentlyPlayedTracksRequest defaultRequest = ITest.SPOTIFY_API
     .getCurrentUsersRecentlyPlayedTracks()

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/GetInformationAboutUsersCurrentPlaybackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/GetInformationAboutUsersCurrentPlaybackRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.CurrentlyPlayingType;
@@ -19,7 +17,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.*;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetInformationAboutUsersCurrentPlaybackRequestTest extends AbstractDataTest<CurrentlyPlayingContext> {
   private final GetInformationAboutUsersCurrentPlaybackRequest defaultRequest = ITest.SPOTIFY_API
     .getInformationAboutUsersCurrentPlayback()

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/GetInformationAboutUsersCurrentPlaybackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/GetInformationAboutUsersCurrentPlaybackRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -54,7 +53,7 @@ public class GetInformationAboutUsersCurrentPlaybackRequestTest extends Abstract
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/me/player?market=SE&additional_types=track%2Cepisode",
       defaultRequest.getUri().toString());
   }
@@ -91,12 +90,12 @@ public class GetInformationAboutUsersCurrentPlaybackRequestTest extends Abstract
       currentlyPlayingContext.getItem());
     assertTrue(
       currentlyPlayingContext.getItem() instanceof Track);
-    Assert.assertEquals(
+    assertEquals(
       CurrentlyPlayingType.TRACK,
       currentlyPlayingContext.getCurrentlyPlayingType());
     assertNotNull(
       currentlyPlayingContext.getActions());
-    Assert.assertEquals(
+    assertEquals(
       2,
       currentlyPlayingContext.getActions().getDisallows().getDisallowedActions().size());
   }
@@ -121,7 +120,7 @@ public class GetInformationAboutUsersCurrentPlaybackRequestTest extends Abstract
       currentlyPlayingContext.getShuffle_state());
     assertNotNull(
       currentlyPlayingContext.getContext());
-    Assert.assertEquals(
+    assertEquals(
       currentlyPlayingContext.getContext().getType(),
       ModelObjectType.SHOW);
     assertEquals(
@@ -136,12 +135,12 @@ public class GetInformationAboutUsersCurrentPlaybackRequestTest extends Abstract
       currentlyPlayingContext.getItem());
     assertTrue(
       currentlyPlayingContext.getItem() instanceof Episode);
-    Assert.assertEquals(
+    assertEquals(
       CurrentlyPlayingType.EPISODE,
       currentlyPlayingContext.getCurrentlyPlayingType());
     assertNotNull(
       currentlyPlayingContext.getActions());
-    Assert.assertEquals(
+    assertEquals(
       4,
       currentlyPlayingContext.getActions().getDisallows().getDisallowedActions().size());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/GetInformationAboutUsersCurrentPlaybackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/GetInformationAboutUsersCurrentPlaybackRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.CurrentlyPlayingType;
@@ -15,7 +15,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class GetInformationAboutUsersCurrentPlaybackRequestTest extends AbstractDataTest<CurrentlyPlayingContext> {
   private final GetInformationAboutUsersCurrentPlaybackRequest defaultRequest = ITest.SPOTIFY_API

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/GetUsersAvailableDevicesTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/GetUsersAvailableDevicesTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -38,7 +37,7 @@ public class GetUsersAvailableDevicesTest extends AbstractDataTest<Device[]> {
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/me/player/devices",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/GetUsersAvailableDevicesTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/GetUsersAvailableDevicesTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -15,7 +13,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetUsersAvailableDevicesTest extends AbstractDataTest<Device[]> {
   private final GetUsersAvailableDevicesRequest defaultRequest = ITest.SPOTIFY_API
     .getUsersAvailableDevices()

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/GetUsersAvailableDevicesTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/GetUsersAvailableDevicesTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -11,7 +11,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class GetUsersAvailableDevicesTest extends AbstractDataTest<Device[]> {
   private final GetUsersAvailableDevicesRequest defaultRequest = ITest.SPOTIFY_API

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/GetUsersCurrentlyPlayingTrackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/GetUsersCurrentlyPlayingTrackRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.CurrentlyPlayingType;
@@ -19,7 +17,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.*;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetUsersCurrentlyPlayingTrackRequestTest extends AbstractDataTest<CurrentlyPlaying> {
   private final GetUsersCurrentlyPlayingTrackRequest defaultRequest = ITest.SPOTIFY_API
     .getUsersCurrentlyPlayingTrack()

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/GetUsersCurrentlyPlayingTrackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/GetUsersCurrentlyPlayingTrackRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -54,7 +53,7 @@ public class GetUsersCurrentlyPlayingTrackRequestTest extends AbstractDataTest<C
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/me/player/currently-playing?market=SE&additional_types=track%2Cepisode",
       defaultRequest.getUri().toString());
   }
@@ -86,10 +85,10 @@ public class GetUsersCurrentlyPlayingTrackRequestTest extends AbstractDataTest<C
       currentlyPlaying.getItem() instanceof Track);
     assertNotNull(
       currentlyPlaying.getActions());
-    Assert.assertEquals(
+    assertEquals(
       4,
       currentlyPlaying.getActions().getDisallows().getDisallowedActions().size());
-    Assert.assertEquals(
+    assertEquals(
       CurrentlyPlayingType.TRACK,
       currentlyPlaying.getCurrentlyPlayingType());
   }
@@ -110,7 +109,7 @@ public class GetUsersCurrentlyPlayingTrackRequestTest extends AbstractDataTest<C
       (long) currentlyPlaying.getTimestamp());
     assertNotNull(
       currentlyPlaying.getContext());
-    Assert.assertEquals(
+    assertEquals(
       currentlyPlaying.getContext().getType(),
       ModelObjectType.SHOW);
     assertEquals(
@@ -120,12 +119,12 @@ public class GetUsersCurrentlyPlayingTrackRequestTest extends AbstractDataTest<C
       currentlyPlaying.getItem());
     assertTrue(
       currentlyPlaying.getItem() instanceof Episode);
-    Assert.assertEquals(
+    assertEquals(
       CurrentlyPlayingType.EPISODE,
       currentlyPlaying.getCurrentlyPlayingType());
     assertNotNull(
       currentlyPlaying.getActions());
-    Assert.assertEquals(
+    assertEquals(
       4,
       currentlyPlaying.getActions().getDisallows().getDisallowedActions().size());
     assertTrue(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/GetUsersCurrentlyPlayingTrackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/GetUsersCurrentlyPlayingTrackRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.CurrentlyPlayingType;
@@ -15,7 +15,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class GetUsersCurrentlyPlayingTrackRequestTest extends AbstractDataTest<CurrentlyPlaying> {
   private final GetUsersCurrentlyPlayingTrackRequest defaultRequest = ITest.SPOTIFY_API

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/PauseUsersPlaybackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/PauseUsersPlaybackRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -16,7 +14,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
-@RunWith(MockitoJUnitRunner.class)
 public class PauseUsersPlaybackRequestTest extends AbstractDataTest<String> {
   private final PauseUsersPlaybackRequest defaultRequest = ITest.SPOTIFY_API
     .pauseUsersPlayback()

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/PauseUsersPlaybackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/PauseUsersPlaybackRequestTest.java
@@ -1,11 +1,9 @@
 package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
-import se.michaelthelin.spotify.Assertions;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -14,7 +12,9 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PauseUsersPlaybackRequestTest extends AbstractDataTest<String> {
@@ -31,8 +31,8 @@ public class PauseUsersPlaybackRequestTest extends AbstractDataTest<String> {
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assertions.assertHasHeader(defaultRequest, "Content-Type", "application/json");
-    Assert.assertEquals(
+    assertHasHeader(defaultRequest, "Content-Type", "application/json");
+    assertEquals(
       "https://api.spotify.com:443/v1/me/player/pause?device_id=5fbb3ba6aa454b5534c4ba43a8c7e8e45a63ad0e",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/PauseUsersPlaybackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/PauseUsersPlaybackRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -10,8 +10,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 public class PauseUsersPlaybackRequestTest extends AbstractDataTest<String> {

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/SeekToPositionInCurrentlyPlayingTrackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/SeekToPositionInCurrentlyPlayingTrackRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -16,7 +14,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SeekToPositionInCurrentlyPlayingTrackRequestTest extends AbstractDataTest<String> {
   private final SeekToPositionInCurrentlyPlayingTrackRequest defaultRequest = ITest.SPOTIFY_API
     .seekToPositionInCurrentlyPlayingTrack(ITest.POSITION_MS)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/SeekToPositionInCurrentlyPlayingTrackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/SeekToPositionInCurrentlyPlayingTrackRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -10,8 +10,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 public class SeekToPositionInCurrentlyPlayingTrackRequestTest extends AbstractDataTest<String> {

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/SeekToPositionInCurrentlyPlayingTrackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/SeekToPositionInCurrentlyPlayingTrackRequestTest.java
@@ -1,11 +1,9 @@
 package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
-import se.michaelthelin.spotify.Assertions;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -14,7 +12,9 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SeekToPositionInCurrentlyPlayingTrackRequestTest extends AbstractDataTest<String> {
@@ -31,8 +31,8 @@ public class SeekToPositionInCurrentlyPlayingTrackRequestTest extends AbstractDa
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assertions.assertHasHeader(defaultRequest, "Content-Type", "application/json");
-    Assert.assertEquals(
+    assertHasHeader(defaultRequest, "Content-Type", "application/json");
+    assertEquals(
       "https://api.spotify.com:443/v1/me/player/seek?position_ms=10000&device_id=5fbb3ba6aa454b5534c4ba43a8c7e8e45a63ad0e",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/SetRepeatModeOnUsersPlaybackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/SetRepeatModeOnUsersPlaybackRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -10,8 +10,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 public class SetRepeatModeOnUsersPlaybackRequestTest extends AbstractDataTest<String> {

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/SetRepeatModeOnUsersPlaybackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/SetRepeatModeOnUsersPlaybackRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -16,7 +14,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SetRepeatModeOnUsersPlaybackRequestTest extends AbstractDataTest<String> {
   private final SetRepeatModeOnUsersPlaybackRequest defaultRequest = ITest.SPOTIFY_API
     .setRepeatModeOnUsersPlayback(ITest.STATE)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/SetRepeatModeOnUsersPlaybackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/SetRepeatModeOnUsersPlaybackRequestTest.java
@@ -1,11 +1,9 @@
 package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
-import se.michaelthelin.spotify.Assertions;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -14,7 +12,9 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SetRepeatModeOnUsersPlaybackRequestTest extends AbstractDataTest<String> {
@@ -31,8 +31,8 @@ public class SetRepeatModeOnUsersPlaybackRequestTest extends AbstractDataTest<St
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assertions.assertHasHeader(defaultRequest, "Content-Type", "application/json");
-    Assert.assertEquals(
+    assertHasHeader(defaultRequest, "Content-Type", "application/json");
+    assertEquals(
       "https://api.spotify.com:443/v1/me/player/repeat?state=track&device_id=5fbb3ba6aa454b5534c4ba43a8c7e8e45a63ad0e",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/SetVolumeForUsersPlaybackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/SetVolumeForUsersPlaybackRequestTest.java
@@ -1,11 +1,9 @@
 package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
-import se.michaelthelin.spotify.Assertions;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -14,7 +12,9 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SetVolumeForUsersPlaybackRequestTest extends AbstractDataTest<String> {
@@ -31,8 +31,8 @@ public class SetVolumeForUsersPlaybackRequestTest extends AbstractDataTest<Strin
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assertions.assertHasHeader(defaultRequest, "Content-Type", "application/json");
-    Assert.assertEquals(
+    assertHasHeader(defaultRequest, "Content-Type", "application/json");
+    assertEquals(
       "https://api.spotify.com:443/v1/me/player/volume?volume_percent=100&device_id=5fbb3ba6aa454b5534c4ba43a8c7e8e45a63ad0e",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/SetVolumeForUsersPlaybackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/SetVolumeForUsersPlaybackRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -10,8 +10,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 public class SetVolumeForUsersPlaybackRequestTest extends AbstractDataTest<String> {

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/SetVolumeForUsersPlaybackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/SetVolumeForUsersPlaybackRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -16,7 +14,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SetVolumeForUsersPlaybackRequestTest extends AbstractDataTest<String> {
   private final SetVolumeForUsersPlaybackRequest defaultRequest = ITest.SPOTIFY_API
     .setVolumeForUsersPlayback(ITest.VOLUME_PERCENT)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/SkipUsersPlaybackToNextTrackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/SkipUsersPlaybackToNextTrackRequestTest.java
@@ -1,11 +1,9 @@
 package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
-import se.michaelthelin.spotify.Assertions;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -14,7 +12,9 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SkipUsersPlaybackToNextTrackRequestTest extends AbstractDataTest<String> {
@@ -31,8 +31,8 @@ public class SkipUsersPlaybackToNextTrackRequestTest extends AbstractDataTest<St
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assertions.assertHasHeader(defaultRequest, "Content-Type", "application/json");
-    Assert.assertEquals(
+    assertHasHeader(defaultRequest, "Content-Type", "application/json");
+    assertEquals(
       "https://api.spotify.com:443/v1/me/player/next?device_id=5fbb3ba6aa454b5534c4ba43a8c7e8e45a63ad0e",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/SkipUsersPlaybackToNextTrackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/SkipUsersPlaybackToNextTrackRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -16,7 +14,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SkipUsersPlaybackToNextTrackRequestTest extends AbstractDataTest<String> {
   private final SkipUsersPlaybackToNextTrackRequest defaultRequest = ITest.SPOTIFY_API
     .skipUsersPlaybackToNextTrack()

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/SkipUsersPlaybackToNextTrackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/SkipUsersPlaybackToNextTrackRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -10,8 +10,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 public class SkipUsersPlaybackToNextTrackRequestTest extends AbstractDataTest<String> {

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/SkipUsersPlaybackToPreviousTrackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/SkipUsersPlaybackToPreviousTrackRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -10,8 +10,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 public class SkipUsersPlaybackToPreviousTrackRequestTest extends AbstractDataTest<String> {

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/SkipUsersPlaybackToPreviousTrackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/SkipUsersPlaybackToPreviousTrackRequestTest.java
@@ -4,7 +4,6 @@ import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
-import se.michaelthelin.spotify.Assertions;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -15,6 +14,7 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SkipUsersPlaybackToPreviousTrackRequestTest extends AbstractDataTest<String> {
@@ -31,7 +31,7 @@ public class SkipUsersPlaybackToPreviousTrackRequestTest extends AbstractDataTes
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assertions.assertHasHeader(defaultRequest, "Content-Type", "application/json");
+    assertHasHeader(defaultRequest, "Content-Type", "application/json");
     assertEquals(
       "https://api.spotify.com:443/v1/me/player/previous?device_id=5fbb3ba6aa454b5534c4ba43a8c7e8e45a63ad0e",
       defaultRequest.getUri().toString());

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/SkipUsersPlaybackToPreviousTrackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/SkipUsersPlaybackToPreviousTrackRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -16,7 +14,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SkipUsersPlaybackToPreviousTrackRequestTest extends AbstractDataTest<String> {
   private final SkipUsersPlaybackToPreviousTrackRequest defaultRequest = ITest.SPOTIFY_API
     .skipUsersPlaybackToPreviousTrack()

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/StartResumeUsersPlaybackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/StartResumeUsersPlaybackRequestTest.java
@@ -1,11 +1,9 @@
 package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
-import se.michaelthelin.spotify.Assertions;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -14,7 +12,10 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
+import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StartResumeUsersPlaybackRequestTest extends AbstractDataTest<String> {
@@ -35,24 +36,24 @@ public class StartResumeUsersPlaybackRequestTest extends AbstractDataTest<String
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assertions.assertHasHeader(defaultRequest, "Content-Type", "application/json");
-    Assertions.assertHasBodyParameter(
+    assertHasHeader(defaultRequest, "Content-Type", "application/json");
+    assertHasBodyParameter(
       defaultRequest,
       "context_uri",
       ITest.CONTEXT_URI);
-    Assertions.assertHasBodyParameter(
+    assertHasBodyParameter(
       defaultRequest,
       "uris",
       ITest.URIS);
-    Assertions.assertHasBodyParameter(
+    assertHasBodyParameter(
       defaultRequest,
       "offset",
       ITest.OFFSET_JSON);
-    Assertions.assertHasBodyParameter(
+    assertHasBodyParameter(
       defaultRequest,
       "position_ms",
       ITest.POSITION_MS);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/me/player/play?device_id=5fbb3ba6aa454b5534c4ba43a8c7e8e45a63ad0e",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/StartResumeUsersPlaybackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/StartResumeUsersPlaybackRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -10,8 +10,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/StartResumeUsersPlaybackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/StartResumeUsersPlaybackRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -17,7 +15,6 @@ import static org.junit.Assert.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
-@RunWith(MockitoJUnitRunner.class)
 public class StartResumeUsersPlaybackRequestTest extends AbstractDataTest<String> {
   private final StartResumeUsersPlaybackRequest defaultRequest = ITest.SPOTIFY_API
     .startResumeUsersPlayback()

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/ToggleShuffleForUsersPlaybackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/ToggleShuffleForUsersPlaybackRequestTest.java
@@ -1,11 +1,9 @@
 package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
-import se.michaelthelin.spotify.Assertions;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -14,7 +12,9 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ToggleShuffleForUsersPlaybackRequestTest extends AbstractDataTest<String> {
@@ -31,8 +31,8 @@ public class ToggleShuffleForUsersPlaybackRequestTest extends AbstractDataTest<S
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assertions.assertHasHeader(defaultRequest, "Content-Type", "application/json");
-    Assert.assertEquals(
+    assertHasHeader(defaultRequest, "Content-Type", "application/json");
+    assertEquals(
       "https://api.spotify.com:443/v1/me/player/shuffle?state=false&device_id=5fbb3ba6aa454b5534c4ba43a8c7e8e45a63ad0e",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/ToggleShuffleForUsersPlaybackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/ToggleShuffleForUsersPlaybackRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -16,7 +14,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
-@RunWith(MockitoJUnitRunner.class)
 public class ToggleShuffleForUsersPlaybackRequestTest extends AbstractDataTest<String> {
   private final ToggleShuffleForUsersPlaybackRequest defaultRequest = ITest.SPOTIFY_API
     .toggleShuffleForUsersPlayback(ITest.STATE_BOOLEAN)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/ToggleShuffleForUsersPlaybackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/ToggleShuffleForUsersPlaybackRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.player;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -10,8 +10,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 public class ToggleShuffleForUsersPlaybackRequestTest extends AbstractDataTest<String> {

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/TransferUsersPlaybackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/TransferUsersPlaybackRequestTest.java
@@ -2,7 +2,7 @@ package se.michaelthelin.spotify.requests.data.player;
 
 import com.google.gson.JsonParser;
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -11,8 +11,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/TransferUsersPlaybackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/TransferUsersPlaybackRequestTest.java
@@ -2,11 +2,9 @@ package se.michaelthelin.spotify.requests.data.player;
 
 import com.google.gson.JsonParser;
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
-import se.michaelthelin.spotify.Assertions;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -15,7 +13,10 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
+import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TransferUsersPlaybackRequestTest extends AbstractDataTest<String> {
@@ -32,16 +33,16 @@ public class TransferUsersPlaybackRequestTest extends AbstractDataTest<String> {
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assertions.assertHasHeader(defaultRequest, "Content-Type", "application/json");
-    Assertions.assertHasBodyParameter(
+    assertHasHeader(defaultRequest, "Content-Type", "application/json");
+    assertHasBodyParameter(
       defaultRequest,
       "device_ids",
       "[\"" + ITest.DEVICE_ID + "\"]");
-    Assertions.assertHasBodyParameter(
+    assertHasBodyParameter(
       defaultRequest,
       "play",
       ITest.PLAY);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/me/player",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/TransferUsersPlaybackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/TransferUsersPlaybackRequestTest.java
@@ -3,8 +3,6 @@ package se.michaelthelin.spotify.requests.data.player;
 import com.google.gson.JsonParser;
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -18,7 +16,6 @@ import static org.junit.Assert.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
-@RunWith(MockitoJUnitRunner.class)
 public class TransferUsersPlaybackRequestTest extends AbstractDataTest<String> {
   private final TransferUsersPlaybackRequest defaultRequest = ITest.SPOTIFY_API
     .transferUsersPlayback(JsonParser.parseString("[\"" + ITest.DEVICE_ID + "\"]").getAsJsonArray())

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/AddItemsToPlaylistRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/AddItemsToPlaylistRequestTest.java
@@ -3,8 +3,6 @@ package se.michaelthelin.spotify.requests.data.playlists;
 import com.google.gson.Gson;
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -18,7 +16,6 @@ import static org.junit.Assert.assertEquals;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
-@RunWith(MockitoJUnitRunner.class)
 public class AddItemsToPlaylistRequestTest extends AbstractDataTest<SnapshotResult> {
   private final AddItemsToPlaylistRequest defaultRequest = ITest.SPOTIFY_API
     .addItemsToPlaylist(ITest.ID_PLAYLIST, new Gson().fromJson(ITest.URIS, String[].class))

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/AddItemsToPlaylistRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/AddItemsToPlaylistRequestTest.java
@@ -2,11 +2,9 @@ package se.michaelthelin.spotify.requests.data.playlists;
 
 import com.google.gson.Gson;
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
-import se.michaelthelin.spotify.Assertions;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -17,6 +15,8 @@ import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
+import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
+import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AddItemsToPlaylistRequestTest extends AbstractDataTest<SnapshotResult> {
@@ -41,21 +41,21 @@ public class AddItemsToPlaylistRequestTest extends AbstractDataTest<SnapshotResu
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/playlists/3AGOiaoRXMSjswCLtuNqv5/tracks?uris=spotify%3Atrack%3A01iyCAUm8EvOFqVWYJ3dVX%2Cspotify%3Atrack%3A01iyCAUm8EvOFqVWYJ3dVX&position=0",
       defaultRequest.getUri().toString());
 
     assertHasAuthorizationHeader(bodyRequest);
-    Assertions.assertHasHeader(defaultRequest, "Content-Type", "application/json");
-    Assertions.assertHasBodyParameter(
+    assertHasHeader(defaultRequest, "Content-Type", "application/json");
+    assertHasBodyParameter(
       bodyRequest,
       "uris",
       ITest.URIS);
-    Assertions.assertHasBodyParameter(
+    assertHasBodyParameter(
       bodyRequest,
       "position",
       ITest.POSITION);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/playlists/3AGOiaoRXMSjswCLtuNqv5/tracks",
       bodyRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/AddItemsToPlaylistRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/AddItemsToPlaylistRequestTest.java
@@ -2,7 +2,7 @@ package se.michaelthelin.spotify.requests.data.playlists;
 
 import com.google.gson.Gson;
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -12,7 +12,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/ChangePlaylistsDetailsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/ChangePlaylistsDetailsRequestTest.java
@@ -1,11 +1,9 @@
 package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
-import se.michaelthelin.spotify.Assertions;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -14,7 +12,10 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
+import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ChangePlaylistsDetailsRequestTest extends AbstractDataTest<String> {
@@ -34,24 +35,24 @@ public class ChangePlaylistsDetailsRequestTest extends AbstractDataTest<String> 
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assertions.assertHasHeader(defaultRequest, "Content-Type", "application/json");
-    Assertions.assertHasBodyParameter(
+    assertHasHeader(defaultRequest, "Content-Type", "application/json");
+    assertHasBodyParameter(
       defaultRequest,
       "name",
       ITest.NAME);
-    Assertions.assertHasBodyParameter(
+    assertHasBodyParameter(
       defaultRequest,
       "public",
       ITest.PUBLIC);
-    Assertions.assertHasBodyParameter(
+    assertHasBodyParameter(
       defaultRequest,
       "collaborative",
       ITest.COLLABORATIVE);
-    Assertions.assertHasBodyParameter(
+    assertHasBodyParameter(
       defaultRequest,
       "description",
       ITest.DESCRIPTION);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/playlists/3AGOiaoRXMSjswCLtuNqv5",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/ChangePlaylistsDetailsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/ChangePlaylistsDetailsRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -17,7 +15,6 @@ import static org.junit.Assert.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
-@RunWith(MockitoJUnitRunner.class)
 public class ChangePlaylistsDetailsRequestTest extends AbstractDataTest<String> {
   private final ChangePlaylistsDetailsRequest defaultRequest = ITest.SPOTIFY_API
     .changePlaylistsDetails(ITest.ID_PLAYLIST)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/ChangePlaylistsDetailsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/ChangePlaylistsDetailsRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -10,8 +10,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/CreatePlaylistRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/CreatePlaylistRequestTest.java
@@ -1,11 +1,9 @@
 package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
-import se.michaelthelin.spotify.Assertions;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.ModelObjectType;
@@ -17,6 +15,7 @@ import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.*;
+import static se.michaelthelin.spotify.Assertions.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CreatePlaylistRequestTest extends AbstractDataTest<Playlist> {
@@ -36,24 +35,24 @@ public class CreatePlaylistRequestTest extends AbstractDataTest<Playlist> {
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assertions.assertHasHeader(defaultRequest, "Content-Type", "application/json");
-    Assertions.assertHasBodyParameter(
+    assertHasHeader(defaultRequest, "Content-Type", "application/json");
+    assertHasBodyParameter(
       defaultRequest,
       "name",
       ITest.NAME);
-    Assertions.assertHasBodyParameter(
+    assertHasBodyParameter(
       defaultRequest,
       "public",
       ITest.PUBLIC);
-    Assertions.assertHasBodyParameter(
+    assertHasBodyParameter(
       defaultRequest,
       "collaborative",
       ITest.COLLABORATIVE);
-    Assertions.assertHasBodyParameter(
+    assertHasBodyParameter(
       defaultRequest,
       "description",
       ITest.DESCRIPTION);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/users/abbaspotify/playlists",
       defaultRequest.getUri().toString());
   }
@@ -98,7 +97,7 @@ public class CreatePlaylistRequestTest extends AbstractDataTest<Playlist> {
       playlist.getSnapshotId());
     assertNotNull(
       playlist.getTracks());
-    Assert.assertEquals(
+    assertEquals(
       ModelObjectType.PLAYLIST,
       playlist.getType());
     assertEquals(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/CreatePlaylistRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/CreatePlaylistRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.ModelObjectType;
@@ -12,7 +12,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static se.michaelthelin.spotify.Assertions.*;
 
 public class CreatePlaylistRequestTest extends AbstractDataTest<Playlist> {

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/CreatePlaylistRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/CreatePlaylistRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.ModelObjectType;
@@ -17,7 +15,6 @@ import java.util.concurrent.ExecutionException;
 import static org.junit.Assert.*;
 import static se.michaelthelin.spotify.Assertions.*;
 
-@RunWith(MockitoJUnitRunner.class)
 public class CreatePlaylistRequestTest extends AbstractDataTest<Playlist> {
   private final CreatePlaylistRequest defaultRequest = ITest.SPOTIFY_API
     .createPlaylist(ITest.ID_USER, ITest.NAME)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/GetListOfCurrentUsersPlaylistsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/GetListOfCurrentUsersPlaylistsRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -12,8 +12,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class GetListOfCurrentUsersPlaylistsRequestTest extends AbstractDataTest<Paging<PlaylistSimplified>> {
   private final GetListOfCurrentUsersPlaylistsRequest defaultRequest = ITest.SPOTIFY_API

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/GetListOfCurrentUsersPlaylistsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/GetListOfCurrentUsersPlaylistsRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -35,7 +34,7 @@ public class GetListOfCurrentUsersPlaylistsRequestTest extends AbstractDataTest<
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/me/playlists?limit=10&offset=0",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/GetListOfCurrentUsersPlaylistsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/GetListOfCurrentUsersPlaylistsRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -17,7 +15,6 @@ import java.util.concurrent.ExecutionException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetListOfCurrentUsersPlaylistsRequestTest extends AbstractDataTest<Paging<PlaylistSimplified>> {
   private final GetListOfCurrentUsersPlaylistsRequest defaultRequest = ITest.SPOTIFY_API
     .getListOfCurrentUsersPlaylists()

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/GetListOfUsersPlaylistsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/GetListOfUsersPlaylistsRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -12,8 +12,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class GetListOfUsersPlaylistsRequestTest extends AbstractDataTest<Paging<PlaylistSimplified>> {
   private final GetListOfUsersPlaylistsRequest defaultRequest = ITest.SPOTIFY_API

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/GetListOfUsersPlaylistsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/GetListOfUsersPlaylistsRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -17,7 +15,6 @@ import java.util.concurrent.ExecutionException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetListOfUsersPlaylistsRequestTest extends AbstractDataTest<Paging<PlaylistSimplified>> {
   private final GetListOfUsersPlaylistsRequest defaultRequest = ITest.SPOTIFY_API
     .getListOfUsersPlaylists(ITest.ID_USER)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/GetListOfUsersPlaylistsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/GetListOfUsersPlaylistsRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -35,7 +34,7 @@ public class GetListOfUsersPlaylistsRequestTest extends AbstractDataTest<Paging<
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/users/abbaspotify/playlists?limit=10&offset=0",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/GetPlaylistCoverImageRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/GetPlaylistCoverImageRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -11,7 +11,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class GetPlaylistCoverImageRequestTest extends AbstractDataTest<Image[]> {
   private final GetPlaylistCoverImageRequest defaultRequest = ITest.SPOTIFY_API

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/GetPlaylistCoverImageRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/GetPlaylistCoverImageRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -31,7 +30,7 @@ public class GetPlaylistCoverImageRequestTest extends AbstractDataTest<Image[]> 
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/playlists/3AGOiaoRXMSjswCLtuNqv5/images",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/GetPlaylistCoverImageRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/GetPlaylistCoverImageRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -15,7 +13,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetPlaylistCoverImageRequestTest extends AbstractDataTest<Image[]> {
   private final GetPlaylistCoverImageRequest defaultRequest = ITest.SPOTIFY_API
     .getPlaylistCoverImage(ITest.ID_PLAYLIST)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/GetPlaylistRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/GetPlaylistRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -35,7 +34,7 @@ public class GetPlaylistRequestTest extends AbstractDataTest<Playlist> {
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/playlists/3AGOiaoRXMSjswCLtuNqv5?fields=description&market=SE&additional_types=track%2Cepisode",
       defaultRequest.getUri().toString());
   }
@@ -81,7 +80,7 @@ public class GetPlaylistRequestTest extends AbstractDataTest<Playlist> {
       playlist.getSnapshotId());
     assertNotNull(
       playlist.getTracks());
-    Assert.assertEquals(
+    assertEquals(
       ModelObjectType.PLAYLIST,
       playlist.getType());
     assertEquals(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/GetPlaylistRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/GetPlaylistRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.ModelObjectType;
@@ -16,7 +14,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.*;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetPlaylistRequestTest extends AbstractDataTest<Playlist> {
   private final GetPlaylistRequest defaultRequest = ITest.SPOTIFY_API
     .getPlaylist(ITest.ID_PLAYLIST)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/GetPlaylistRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/GetPlaylistRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.ModelObjectType;
@@ -12,7 +12,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class GetPlaylistRequestTest extends AbstractDataTest<Playlist> {
   private final GetPlaylistRequest defaultRequest = ITest.SPOTIFY_API

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/GetPlaylistsItemsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/GetPlaylistsItemsRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -51,7 +50,7 @@ public class GetPlaylistsItemsRequestTest extends AbstractDataTest<Paging<Playli
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/playlists/3AGOiaoRXMSjswCLtuNqv5/tracks?fields=description&limit=10&market=SE&offset=0&additional_types=track%2Cepisode",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/GetPlaylistsItemsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/GetPlaylistsItemsRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -18,7 +16,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.*;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetPlaylistsItemsRequestTest extends AbstractDataTest<Paging<PlaylistTrack>> {
   private final GetPlaylistsItemsRequest defaultRequest = ITest.SPOTIFY_API
     .getPlaylistsItems(ITest.ID_PLAYLIST)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/GetPlaylistsItemsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/GetPlaylistsItemsRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -14,7 +14,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class GetPlaylistsItemsRequestTest extends AbstractDataTest<Paging<PlaylistTrack>> {
   private final GetPlaylistsItemsRequest defaultRequest = ITest.SPOTIFY_API

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/RemoveItemsFromPlaylistRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/RemoveItemsFromPlaylistRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -16,7 +14,6 @@ import java.util.concurrent.ExecutionException;
 import static org.junit.Assert.assertEquals;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 
-@RunWith(MockitoJUnitRunner.class)
 public class RemoveItemsFromPlaylistRequestTest extends AbstractDataTest<SnapshotResult> {
   private final RemoveItemsFromPlaylistRequest defaultRequest = ITest.SPOTIFY_API
     .removeItemsFromPlaylist(ITest.ID_PLAYLIST, ITest.TRACKS)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/RemoveItemsFromPlaylistRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/RemoveItemsFromPlaylistRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -11,7 +11,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 
 public class RemoveItemsFromPlaylistRequestTest extends AbstractDataTest<SnapshotResult> {

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/RemoveItemsFromPlaylistRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/RemoveItemsFromPlaylistRequestTest.java
@@ -1,11 +1,9 @@
 package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
-import se.michaelthelin.spotify.Assertions;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -16,6 +14,7 @@ import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
+import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RemoveItemsFromPlaylistRequestTest extends AbstractDataTest<SnapshotResult> {
@@ -33,11 +32,11 @@ public class RemoveItemsFromPlaylistRequestTest extends AbstractDataTest<Snapsho
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assertions.assertHasBodyParameter(
+    assertHasBodyParameter(
       defaultRequest,
       "tracks",
       ITest.TRACKS);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/playlists/3AGOiaoRXMSjswCLtuNqv5/tracks",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/ReorderPlaylistsItemsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/ReorderPlaylistsItemsRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -11,7 +11,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/ReorderPlaylistsItemsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/ReorderPlaylistsItemsRequestTest.java
@@ -1,11 +1,9 @@
 package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
-import se.michaelthelin.spotify.Assertions;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -16,6 +14,8 @@ import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
+import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
+import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ReorderPlaylistsItemsRequestTest extends AbstractDataTest<SnapshotResult> {
@@ -34,24 +34,24 @@ public class ReorderPlaylistsItemsRequestTest extends AbstractDataTest<SnapshotR
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assertions.assertHasHeader(defaultRequest, "Content-Type", "application/json");
-    Assertions.assertHasBodyParameter(
+    assertHasHeader(defaultRequest, "Content-Type", "application/json");
+    assertHasBodyParameter(
       defaultRequest,
       "range_start",
       ITest.RANGE_START);
-    Assertions.assertHasBodyParameter(
+    assertHasBodyParameter(
       defaultRequest,
       "range_length",
       ITest.RANGE_LENGTH);
-    Assertions.assertHasBodyParameter(
+    assertHasBodyParameter(
       defaultRequest,
       "insert_before",
       ITest.INSERT_BEFORE);
-    Assertions.assertHasBodyParameter(
+    assertHasBodyParameter(
       defaultRequest,
       "snapshot_id",
       ITest.SNAPSHOT_ID);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/playlists/3AGOiaoRXMSjswCLtuNqv5/tracks",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/ReorderPlaylistsItemsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/ReorderPlaylistsItemsRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -17,7 +15,6 @@ import static org.junit.Assert.assertEquals;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
-@RunWith(MockitoJUnitRunner.class)
 public class ReorderPlaylistsItemsRequestTest extends AbstractDataTest<SnapshotResult> {
   private final ReorderPlaylistsItemsRequest defaultRequest = ITest.SPOTIFY_API
     .reorderPlaylistsItems(ITest.ID_PLAYLIST, ITest.RANGE_START, ITest.INSERT_BEFORE)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/ReplacePlaylistsItemsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/ReplacePlaylistsItemsRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -17,7 +15,6 @@ import static org.junit.Assert.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
-@RunWith(MockitoJUnitRunner.class)
 public class ReplacePlaylistsItemsRequestTest extends AbstractDataTest<String> {
   private final ReplacePlaylistsItemsRequest defaultRequest = ITest.SPOTIFY_API
     .replacePlaylistsItems(ITest.ID_PLAYLIST, new String[]{"spotify:track:" + ITest.ID_TRACK, "spotify:track:" + ITest.ID_TRACK})

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/ReplacePlaylistsItemsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/ReplacePlaylistsItemsRequestTest.java
@@ -1,11 +1,9 @@
 package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
-import se.michaelthelin.spotify.Assertions;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -14,7 +12,10 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
+import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ReplacePlaylistsItemsRequestTest extends AbstractDataTest<String> {
@@ -35,17 +36,17 @@ public class ReplacePlaylistsItemsRequestTest extends AbstractDataTest<String> {
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/playlists/3AGOiaoRXMSjswCLtuNqv5/tracks?uris=spotify%3Atrack%3A01iyCAUm8EvOFqVWYJ3dVX%2Cspotify%3Atrack%3A01iyCAUm8EvOFqVWYJ3dVX",
       defaultRequest.getUri().toString());
 
     assertHasAuthorizationHeader(bodyRequest);
-    Assertions.assertHasHeader(defaultRequest, "Content-Type", "application/json");
-    Assertions.assertHasBodyParameter(
+    assertHasHeader(defaultRequest, "Content-Type", "application/json");
+    assertHasBodyParameter(
       bodyRequest,
       "uris",
       ITest.TRACKS);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/playlists/3AGOiaoRXMSjswCLtuNqv5/tracks",
       bodyRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/ReplacePlaylistsItemsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/ReplacePlaylistsItemsRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -10,8 +10,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/UploadCustomPlaylistCoverImageRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/UploadCustomPlaylistCoverImageRequestTest.java
@@ -1,11 +1,9 @@
 package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
-import se.michaelthelin.spotify.Assertions;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -14,8 +12,10 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UploadCustomPlaylistCoverImageRequestTest extends AbstractDataTest<String> {
@@ -32,10 +32,10 @@ public class UploadCustomPlaylistCoverImageRequestTest extends AbstractDataTest<
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assertions.assertHasHeader(defaultRequest, "Content-Type", "image/jpeg");
+    assertHasHeader(defaultRequest, "Content-Type", "image/jpeg");
     assertNotNull(
       defaultRequest.getBody());
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/playlists/3AGOiaoRXMSjswCLtuNqv5/images",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/UploadCustomPlaylistCoverImageRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/UploadCustomPlaylistCoverImageRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -10,9 +10,9 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
 public class UploadCustomPlaylistCoverImageRequestTest extends AbstractDataTest<String> {

--- a/src/test/java/se/michaelthelin/spotify/requests/data/playlists/UploadCustomPlaylistCoverImageRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/playlists/UploadCustomPlaylistCoverImageRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.playlists;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -17,7 +15,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static se.michaelthelin.spotify.Assertions.assertHasHeader;
 
-@RunWith(MockitoJUnitRunner.class)
 public class UploadCustomPlaylistCoverImageRequestTest extends AbstractDataTest<String> {
   private final UploadCustomPlaylistCoverImageRequest defaultRequest = ITest.SPOTIFY_API
     .uploadCustomPlaylistCoverImage(ITest.ID_PLAYLIST)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/search/SearchItemRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/search/SearchItemRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.search;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -15,6 +14,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -37,7 +37,7 @@ public class SearchItemRequestTest extends AbstractDataTest<SearchResult> {
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/search?q=Abba&type=artist&limit=10&market=SE&offset=0&include_external=audio",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/search/SearchItemRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/search/SearchItemRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.search;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.ModelObjectType;
@@ -12,9 +12,9 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class SearchItemRequestTest extends AbstractDataTest<SearchResult> {
   private final SearchItemRequest defaultRequest = ITest.SPOTIFY_API

--- a/src/test/java/se/michaelthelin/spotify/requests/data/search/SearchItemRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/search/SearchItemRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.search;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.ModelObjectType;
@@ -18,7 +16,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SearchItemRequestTest extends AbstractDataTest<SearchResult> {
   private final SearchItemRequest defaultRequest = ITest.SPOTIFY_API
     .searchItem(ITest.Q, ModelObjectType.ARTIST.getType())

--- a/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchAlbumsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchAlbumsRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.search.simplified;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -16,7 +14,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SearchAlbumsRequestTest extends AbstractDataTest<Paging<AlbumSimplified>> {
   private final SearchAlbumsRequest defaultRequest = ITest.SPOTIFY_API.searchAlbums(ITest.Q)
     .setHttpManager(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchAlbumsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchAlbumsRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.search.simplified;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -35,7 +34,7 @@ public class SearchAlbumsRequestTest extends AbstractDataTest<Paging<AlbumSimpli
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/search?q=Abba&limit=10&market=SE&offset=0&include_external=audio&type=album",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchAlbumsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchAlbumsRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.search.simplified;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -12,7 +12,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SearchAlbumsRequestTest extends AbstractDataTest<Paging<AlbumSimplified>> {
   private final SearchAlbumsRequest defaultRequest = ITest.SPOTIFY_API.searchAlbums(ITest.Q)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchArtistsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchArtistsRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.search.simplified;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -12,7 +12,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SearchArtistsRequestTest extends AbstractDataTest<Paging<Artist>> {
   private final SearchArtistsRequest defaultRequest = ITest.SPOTIFY_API.searchArtists(ITest.Q)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchArtistsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchArtistsRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.search.simplified;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -35,7 +34,7 @@ public class SearchArtistsRequestTest extends AbstractDataTest<Paging<Artist>> {
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/search?q=Abba&limit=10&market=SE&offset=0&include_external=audio&type=artist",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchArtistsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchArtistsRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.search.simplified;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -16,7 +14,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SearchArtistsRequestTest extends AbstractDataTest<Paging<Artist>> {
   private final SearchArtistsRequest defaultRequest = ITest.SPOTIFY_API.searchArtists(ITest.Q)
     .setHttpManager(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchEpisodesRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchEpisodesRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.search.simplified;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -16,7 +14,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SearchEpisodesRequestTest extends AbstractDataTest<Paging<EpisodeSimplified>> {
   private final SearchEpisodesRequest defaultRequest = ITest.SPOTIFY_API.searchEpisodes(ITest.Q)
     .setHttpManager(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchEpisodesRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchEpisodesRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.search.simplified;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -12,7 +12,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SearchEpisodesRequestTest extends AbstractDataTest<Paging<EpisodeSimplified>> {
   private final SearchEpisodesRequest defaultRequest = ITest.SPOTIFY_API.searchEpisodes(ITest.Q)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchEpisodesRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchEpisodesRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.search.simplified;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -35,7 +34,7 @@ public class SearchEpisodesRequestTest extends AbstractDataTest<Paging<EpisodeSi
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/search?q=Abba&limit=10&market=SE&offset=0&include_external=audio&type=episode",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchPlaylistsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchPlaylistsRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.search.simplified;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -16,7 +14,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SearchPlaylistsRequestTest extends AbstractDataTest<Paging<PlaylistSimplified>> {
   private final SearchPlaylistsRequest defaultRequest = ITest.SPOTIFY_API
     .searchPlaylists(ITest.Q)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchPlaylistsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchPlaylistsRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.search.simplified;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -12,7 +12,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SearchPlaylistsRequestTest extends AbstractDataTest<Paging<PlaylistSimplified>> {
   private final SearchPlaylistsRequest defaultRequest = ITest.SPOTIFY_API

--- a/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchShowsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchShowsRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.search.simplified;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -16,7 +14,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SearchShowsRequestTest extends AbstractDataTest<Paging<ShowSimplified>> {
   private final SearchShowsRequest defaultRequest = ITest.SPOTIFY_API.searchShows(ITest.Q)
     .setHttpManager(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchShowsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchShowsRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.search.simplified;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -35,7 +34,7 @@ public class SearchShowsRequestTest extends AbstractDataTest<Paging<ShowSimplifi
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/search?q=Abba&limit=10&market=SE&offset=0&include_external=audio&type=show",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchShowsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchShowsRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.search.simplified;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -12,7 +12,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SearchShowsRequestTest extends AbstractDataTest<Paging<ShowSimplified>> {
   private final SearchShowsRequest defaultRequest = ITest.SPOTIFY_API.searchShows(ITest.Q)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchTracksRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchTracksRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.search.simplified;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -12,7 +12,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SearchTracksRequestTest extends AbstractDataTest<Paging<Track>> {
   private final SearchTracksRequest defaultRequest = ITest.SPOTIFY_API

--- a/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchTracksRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchTracksRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.search.simplified;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -16,7 +14,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SearchTracksRequestTest extends AbstractDataTest<Paging<Track>> {
   private final SearchTracksRequest defaultRequest = ITest.SPOTIFY_API
     .searchTracks(ITest.Q)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchTracksRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/SearchTracksRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.search.simplified;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -36,7 +35,7 @@ public class SearchTracksRequestTest extends AbstractDataTest<Paging<Track>> {
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/search?q=Abba&limit=10&market=SE&offset=0&include_external=audio&type=track",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/special/SearchAlbumsSpecialRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/special/SearchAlbumsSpecialRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.search.simplified.special;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -12,7 +12,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SearchAlbumsSpecialRequestTest extends AbstractDataTest<Paging<AlbumSimplifiedSpecial>> {
   private final SearchAlbumsSpecialRequest defaultRequest = ITest.SPOTIFY_API.searchAlbumsSpecial(ITest.Q)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/special/SearchAlbumsSpecialRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/search/simplified/special/SearchAlbumsSpecialRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.search.simplified.special;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -16,7 +14,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SearchAlbumsSpecialRequestTest extends AbstractDataTest<Paging<AlbumSimplifiedSpecial>> {
   private final SearchAlbumsSpecialRequest defaultRequest = ITest.SPOTIFY_API.searchAlbumsSpecial(ITest.Q)
     .setHttpManager(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/shows/GetSeveralShowsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/shows/GetSeveralShowsRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.shows;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.specification.ShowSimplified;
@@ -10,7 +10,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class GetSeveralShowsRequestTest extends AbstractDataTest<ShowSimplified[]> {
 

--- a/src/test/java/se/michaelthelin/spotify/requests/data/shows/GetSeveralShowsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/shows/GetSeveralShowsRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.shows;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.specification.ShowSimplified;
@@ -14,7 +12,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetSeveralShowsRequestTest extends AbstractDataTest<ShowSimplified[]> {
 
   private final GetSeveralShowsRequest defaultRequest = SPOTIFY_API.getSeveralShows(ID_SHOW, ID_SHOW)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/shows/GetShowRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/shows/GetShowRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.shows;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.ModelObjectType;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -15,7 +13,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.*;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetShowRequestTest extends AbstractDataTest<Show> {
   private final GetShowRequest defaultRequest = SPOTIFY_API.getShow(ID_SHOW)
     .setHttpManager(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/shows/GetShowRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/shows/GetShowRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.shows;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.ModelObjectType;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -11,7 +11,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class GetShowRequestTest extends AbstractDataTest<Show> {
   private final GetShowRequest defaultRequest = SPOTIFY_API.getShow(ID_SHOW)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/shows/GetShowsEpisodesRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/shows/GetShowsEpisodesRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.shows;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.specification.EpisodeSimplified;
@@ -11,7 +11,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class GetShowsEpisodesRequestTest extends AbstractDataTest<Paging<EpisodeSimplified>> {
 

--- a/src/test/java/se/michaelthelin/spotify/requests/data/shows/GetShowsEpisodesRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/shows/GetShowsEpisodesRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.shows;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.specification.EpisodeSimplified;
@@ -15,7 +13,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetShowsEpisodesRequestTest extends AbstractDataTest<Paging<EpisodeSimplified>> {
 
   private final GetShowsEpisodesRequest defaultRequest = SPOTIFY_API.getShowEpisodes(ID_SHOW)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetAudioAnalysisForTrackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetAudioAnalysisForTrackRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.tracks;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -33,7 +32,7 @@ public class GetAudioAnalysisForTrackRequestTest extends AbstractDataTest<AudioA
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/audio-analysis/01iyCAUm8EvOFqVWYJ3dVX",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetAudioAnalysisForTrackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetAudioAnalysisForTrackRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.tracks;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.Modality;
@@ -17,7 +15,6 @@ import java.util.concurrent.ExecutionException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetAudioAnalysisForTrackRequestTest extends AbstractDataTest<AudioAnalysis> {
   private final GetAudioAnalysisForTrackRequest defaultRequest = ITest.SPOTIFY_API
     .getAudioAnalysisForTrack(ITest.ID_TRACK)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetAudioAnalysisForTrackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetAudioAnalysisForTrackRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.tracks;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.Modality;
@@ -12,8 +12,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class GetAudioAnalysisForTrackRequestTest extends AbstractDataTest<AudioAnalysis> {
   private final GetAudioAnalysisForTrackRequest defaultRequest = ITest.SPOTIFY_API
@@ -63,8 +63,8 @@ public class GetAudioAnalysisForTrackRequestTest extends AbstractDataTest<AudioA
       1,
       audioAnalysis.getTatums().length);
     assertNotNull(
-      "",
-      audioAnalysis.getTrack());
+      audioAnalysis.getTrack(),
+      "");
     assertEquals(
       Modality.MINOR,
       audioAnalysis.getTrack().getMode());

--- a/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetAudioFeaturesForSeveralTracksRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetAudioFeaturesForSeveralTracksRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.tracks;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -11,7 +11,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class GetAudioFeaturesForSeveralTracksRequestTest extends AbstractDataTest<AudioFeatures[]> {
   private final GetAudioFeaturesForSeveralTracksRequest defaultRequest = ITest.SPOTIFY_API

--- a/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetAudioFeaturesForSeveralTracksRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetAudioFeaturesForSeveralTracksRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.tracks;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -15,7 +13,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetAudioFeaturesForSeveralTracksRequestTest extends AbstractDataTest<AudioFeatures[]> {
   private final GetAudioFeaturesForSeveralTracksRequest defaultRequest = ITest.SPOTIFY_API
     .getAudioFeaturesForSeveralTracks(ITest.ID_TRACK, ITest.ID_TRACK)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetAudioFeaturesForSeveralTracksRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetAudioFeaturesForSeveralTracksRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.tracks;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -31,7 +30,7 @@ public class GetAudioFeaturesForSeveralTracksRequestTest extends AbstractDataTes
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/audio-features?ids=01iyCAUm8EvOFqVWYJ3dVX%2C01iyCAUm8EvOFqVWYJ3dVX",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetAudioFeaturesForTrackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetAudioFeaturesForTrackRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.tracks;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -33,7 +32,7 @@ public class GetAudioFeaturesForTrackRequestTest extends AbstractDataTest<AudioF
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/audio-features/01iyCAUm8EvOFqVWYJ3dVX",
       defaultRequest.getUri().toString());
   }
@@ -79,7 +78,7 @@ public class GetAudioFeaturesForTrackRequestTest extends AbstractDataTest<AudioF
     assertEquals(
       -11.840,
       audioFeatures.getLoudness(), 0.001);
-    Assert.assertEquals(
+    assertEquals(
       Modality.MINOR,
       audioFeatures.getMode());
     assertEquals(
@@ -94,7 +93,7 @@ public class GetAudioFeaturesForTrackRequestTest extends AbstractDataTest<AudioF
     assertEquals(
       "https://api.spotify.com/v1/tracks/06AKEBrKUckW0KREUWRnvT",
       audioFeatures.getTrackHref());
-    Assert.assertEquals(
+    assertEquals(
       ModelObjectType.AUDIO_FEATURES,
       audioFeatures.getType());
     assertEquals(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetAudioFeaturesForTrackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetAudioFeaturesForTrackRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.tracks;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.Modality;
@@ -17,7 +15,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetAudioFeaturesForTrackRequestTest extends AbstractDataTest<AudioFeatures> {
   private final GetAudioFeaturesForTrackRequest defaultRequest = ITest.SPOTIFY_API
     .getAudioFeaturesForTrack(ITest.ID_TRACK)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetAudioFeaturesForTrackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetAudioFeaturesForTrackRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.tracks;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.Modality;
@@ -13,7 +13,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class GetAudioFeaturesForTrackRequestTest extends AbstractDataTest<AudioFeatures> {
   private final GetAudioFeaturesForTrackRequest defaultRequest = ITest.SPOTIFY_API

--- a/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetSeveralTracksRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetSeveralTracksRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.tracks;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -11,7 +11,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class GetSeveralTracksRequestTest extends AbstractDataTest<Track[]> {
   private final GetSeveralTracksRequest defaultRequest = ITest.SPOTIFY_API

--- a/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetSeveralTracksRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetSeveralTracksRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.tracks;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -32,7 +31,7 @@ public class GetSeveralTracksRequestTest extends AbstractDataTest<Track[]> {
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/tracks?ids=01iyCAUm8EvOFqVWYJ3dVX&market=SE",
       defaultRequest.getUri().toString());
   }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetSeveralTracksRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetSeveralTracksRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.tracks;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
@@ -15,7 +13,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetSeveralTracksRequestTest extends AbstractDataTest<Track[]> {
   private final GetSeveralTracksRequest defaultRequest = ITest.SPOTIFY_API
     .getSeveralTracks(ITest.ID_TRACK)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetTrackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetTrackRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.tracks;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.ModelObjectType;
@@ -16,7 +14,6 @@ import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.*;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetTrackRequestTest extends AbstractDataTest<Track> {
   private final GetTrackRequest defaultRequest = ITest.SPOTIFY_API
     .getTrack(ITest.ID_TRACK)

--- a/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetTrackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetTrackRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.tracks;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.ModelObjectType;
@@ -12,7 +12,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class GetTrackRequestTest extends AbstractDataTest<Track> {
   private final GetTrackRequest defaultRequest = ITest.SPOTIFY_API
@@ -46,11 +46,11 @@ public class GetTrackRequestTest extends AbstractDataTest<Track> {
 
   public void shouldReturnDefault(final Track track) {
     assertNotNull(
-      "",
-      track.getAlbum());
+      track.getAlbum(),
+      "");
     assertNotNull(
-      "",
-      track.getArtists());
+      track.getArtists(),
+      "");
     assertEquals(
       57,
       track.getAvailableMarkets().length);

--- a/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetTrackRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetTrackRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.tracks;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -33,7 +32,7 @@ public class GetTrackRequestTest extends AbstractDataTest<Track> {
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/tracks/01iyCAUm8EvOFqVWYJ3dVX?market=SE",
       defaultRequest.getUri().toString());
   }
@@ -88,7 +87,7 @@ public class GetTrackRequestTest extends AbstractDataTest<Track> {
     assertEquals(
       2,
       (int) track.getTrackNumber());
-    Assert.assertEquals(
+    assertEquals(
       ModelObjectType.TRACK,
       track.getType());
     assertEquals(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/users_profile/GetCurrentUsersProfileRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/users_profile/GetCurrentUsersProfileRequestTest.java
@@ -2,7 +2,6 @@ package se.michaelthelin.spotify.requests.data.users_profile;
 
 import com.neovisionaries.i18n.CountryCode;
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -35,7 +34,7 @@ public class GetCurrentUsersProfileRequestTest extends AbstractDataTest<User> {
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       "https://api.spotify.com:443/v1/me",
       defaultRequest.getUri().toString());
   }
@@ -76,10 +75,10 @@ public class GetCurrentUsersProfileRequestTest extends AbstractDataTest<User> {
     assertEquals(
       1,
       user.getImages().length);
-    Assert.assertEquals(
+    assertEquals(
       ProductType.PREMIUM,
       user.getProduct());
-    Assert.assertEquals(
+    assertEquals(
       ModelObjectType.USER,
       user.getType());
     assertEquals(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/users_profile/GetCurrentUsersProfileRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/users_profile/GetCurrentUsersProfileRequestTest.java
@@ -3,8 +3,6 @@ package se.michaelthelin.spotify.requests.data.users_profile;
 import com.neovisionaries.i18n.CountryCode;
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.ModelObjectType;
@@ -19,7 +17,6 @@ import java.util.concurrent.ExecutionException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetCurrentUsersProfileRequestTest extends AbstractDataTest<User> {
   private final GetCurrentUsersProfileRequest defaultRequest = ITest.SPOTIFY_API
     .getCurrentUsersProfile()

--- a/src/test/java/se/michaelthelin/spotify/requests/data/users_profile/GetCurrentUsersProfileRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/users_profile/GetCurrentUsersProfileRequestTest.java
@@ -2,7 +2,7 @@ package se.michaelthelin.spotify.requests.data.users_profile;
 
 import com.neovisionaries.i18n.CountryCode;
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.ModelObjectType;
@@ -14,8 +14,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class GetCurrentUsersProfileRequestTest extends AbstractDataTest<User> {
   private final GetCurrentUsersProfileRequest defaultRequest = ITest.SPOTIFY_API

--- a/src/test/java/se/michaelthelin/spotify/requests/data/users_profile/GetUsersProfileRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/users_profile/GetUsersProfileRequestTest.java
@@ -1,7 +1,6 @@
 package se.michaelthelin.spotify.requests.data.users_profile;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -33,7 +32,7 @@ public class GetUsersProfileRequestTest extends AbstractDataTest<User> {
   @Test
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
-    Assert.assertEquals(
+    assertEquals(
       // Yes, ABBA is not spelled that way ;)
       // But it should be ensured non-ASCII characters are handled properly as well.
       // Therefore, "abbaspötify" is used instead of "abbaspotify".
@@ -75,7 +74,7 @@ public class GetUsersProfileRequestTest extends AbstractDataTest<User> {
     assertEquals(
       1,
       user.getImages().length);
-    Assert.assertEquals(
+    assertEquals(
       ModelObjectType.USER,
       user.getType());
     assertEquals(

--- a/src/test/java/se/michaelthelin/spotify/requests/data/users_profile/GetUsersProfileRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/users_profile/GetUsersProfileRequestTest.java
@@ -1,7 +1,7 @@
 package se.michaelthelin.spotify.requests.data.users_profile;
 
 import org.apache.hc.core5.http.ParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.ModelObjectType;
@@ -12,8 +12,8 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class GetUsersProfileRequestTest extends AbstractDataTest<User> {
   private final GetUsersProfileRequest defaultRequest = ITest.SPOTIFY_API

--- a/src/test/java/se/michaelthelin/spotify/requests/data/users_profile/GetUsersProfileRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/users_profile/GetUsersProfileRequestTest.java
@@ -2,8 +2,6 @@ package se.michaelthelin.spotify.requests.data.users_profile;
 
 import org.apache.hc.core5.http.ParseException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.enums.ModelObjectType;
@@ -17,7 +15,6 @@ import java.util.concurrent.ExecutionException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GetUsersProfileRequestTest extends AbstractDataTest<User> {
   private final GetUsersProfileRequest defaultRequest = ITest.SPOTIFY_API
     .getUsersProfile(ITest.ID_USER_NON_ASCII)


### PR DESCRIPTION
This PR upgrades JUnit to the latest available JUnit Jupiter, 5.9.1 in order to make it easier to continue writing and maintaining tests in a supported framework.

It includes the following work:

- Dependencies:
  - Replacing the `junit:junit:4.13.2` dependency with `org.junit.jupiter:junit-jupiter:5.9.1`
- JUnit usage:
  - Using `org.junit.jupiter.api.Test` as a drop-in replacement for `org.junit.Test`
  - Using `org.junit.jupiter.api.Assertions` as a drop-in replacement for `org.junit.Assert` in the common case where an assertion method was used without the optional message argument.
  - In the handful of occasions where an assertion was used with a message, the arguments were reorganized so that the message is the last argument, as expected in `Assertions`' methods.
- Cleanups:
  - The code uses a mixed convention of importing the assertion class (e.g., `org.junit.Assert` or `se.michaelthelin.spotify.Assertions`) and using its method and statically importing the assertion method, sometimes even in the same class. While this isn't a problem per-se, it's sometimes confusing and made the upgrade more difficult. As a preliminary step, these inconsistencies were cleaned up and the usage of assertions was standardized to statically import the relevant method.
  -  None of the tests in the project use Mockito's annotations, and therefore they did not need to use `MockitoJUnitRunner`, so its usages were safely removed.

Individual commit messages contain additional deails.
