### PR TITLE
chore(deps): remove unused dependency mockito

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,8 +405,7 @@ creation.
 #### Tests
 `src/test/java/se.michaelthelin.spotify/`
 
-Unit tests ensure that implemented features work. This project's unit tests are implemented with [JUnit](http://junit.org/)
-and [mockito](http://site.mockito.org/) for mocking.
+Unit tests ensure that implemented features work. This project's unit tests are implemented with [JUnit](http://junit.org/).
 
 ##### Fixtures
 `src/test/fixtures/`

--- a/pom.xml
+++ b/pom.xml
@@ -83,12 +83,6 @@
       <version>5.1.3</version>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.10.19</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>2.0.3</version>


### PR DESCRIPTION
Following #306, mockito is now unused and can thus be removed.