### PR TITLE
Add request for get playback queue endpoint

### DIFF
--- a/src/main/java/se/michaelthelin/spotify/SpotifyApi.java
+++ b/src/main/java/se/michaelthelin/spotify/SpotifyApi.java
@@ -1359,6 +1359,15 @@ public class SpotifyApi {
   }
 
   /**
+   * Receive all tracks from the user's current playback queue.
+   *
+   */
+  public GetListOfTracksFromUsersPlaybackQueueRequest.Builder getListOfTracksFromUsersPlaybackQueue() {
+    return new GetListOfTracksFromUsersPlaybackQueueRequest.Builder(accessToken)
+      .setDefaults(httpManager, scheme, host, port);
+  }
+
+  /**
    * Add items to a playlist.
    * <p>
    * <b>Note:</b> If you want to add a large number of items (&gt;50), use {@link #addItemsToPlaylist(String, JsonArray)} to not exceed

--- a/src/main/java/se/michaelthelin/spotify/model_objects/miscellaneous/PlaybackQueue.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/miscellaneous/PlaybackQueue.java
@@ -1,0 +1,71 @@
+package se.michaelthelin.spotify.model_objects.miscellaneous;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.gson.JsonObject;
+import se.michaelthelin.spotify.model_objects.AbstractModelObject;
+import se.michaelthelin.spotify.model_objects.IModelObject;
+import se.michaelthelin.spotify.model_objects.specification.*;
+
+import java.util.List;
+
+@JsonDeserialize(builder = CurrentlyPlaying.Builder.class)
+public class PlaybackQueue extends AbstractModelObject{
+
+  private final List<Track> queue;
+
+  private PlaybackQueue(final Builder builder) {
+    super(builder);
+    this.queue = builder.queue;
+  }
+
+  public List<Track> getQueue() {
+    return queue;
+  }
+
+  @Override
+  public String toString() {
+    return "PlaybackQueue{" +
+      "queue=" + queue +
+      '}';
+  }
+
+  @Override
+  public IModelObject.Builder builder() {
+    return new Builder();
+  }
+
+
+  public static final class Builder extends AbstractModelObject.Builder {
+
+    private List<Track> queue;
+
+    public Builder setQueue(List<Track> queue) {
+      this.queue = queue;
+      return this;
+    }
+
+    @Override
+    public PlaybackQueue build() {
+      return new PlaybackQueue(this);
+    }
+  }
+
+  /**
+   * JsonUtil class for building {@link CurrentlyPlaying} instances.
+   */
+  public static final class JsonUtil extends AbstractModelObject.JsonUtil<PlaybackQueue> {
+    public PlaybackQueue createModelObject(JsonObject jsonObject) {
+      if (jsonObject == null || jsonObject.isJsonNull()) {
+        return null;
+      }
+
+      return new PlaybackQueue.Builder()
+        .setQueue(
+          hasAndNotNull(jsonObject, "queue")
+            ? List.of(new Track.JsonUtil().createModelObjectArray(
+            jsonObject.getAsJsonArray("queue")))
+            : null)
+        .build();
+    }
+  }
+}

--- a/src/main/java/se/michaelthelin/spotify/model_objects/special/PlaybackQueue.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/special/PlaybackQueue.java
@@ -1,13 +1,20 @@
-package se.michaelthelin.spotify.model_objects.miscellaneous;
+package se.michaelthelin.spotify.model_objects.special;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.gson.JsonObject;
 import se.michaelthelin.spotify.model_objects.AbstractModelObject;
 import se.michaelthelin.spotify.model_objects.IModelObject;
+import se.michaelthelin.spotify.model_objects.miscellaneous.CurrentlyPlaying;
 import se.michaelthelin.spotify.model_objects.specification.*;
 
 import java.util.List;
 
+/**
+ * Includes tracks that are in the queue of the user for the upcoming playback.
+ * <p>
+ * Retrieve information about <a href="https://developer.spotify.com/web-api/object-model/#playback-queue-object">
+ *
+ */
 @JsonDeserialize(builder = CurrentlyPlaying.Builder.class)
 public class PlaybackQueue extends AbstractModelObject{
 
@@ -18,6 +25,11 @@ public class PlaybackQueue extends AbstractModelObject{
     this.queue = builder.queue;
   }
 
+  /**
+   * Get the tracks that are in the queue of the user for the upcoming playback.
+   *
+   * @return The tracks that are in the queue of the user for the upcoming playback.
+   */
   public List<Track> getQueue() {
     return queue;
   }
@@ -34,11 +46,19 @@ public class PlaybackQueue extends AbstractModelObject{
     return new Builder();
   }
 
-
+  /**
+   * Builder class for building {@link PlaybackQueue} instances.
+   */
   public static final class Builder extends AbstractModelObject.Builder {
 
     private List<Track> queue;
 
+    /**
+     * The tracks that are in the queue of the user for the upcoming playback setter.
+     *
+     * @param queue The tracks that are in the queue of the user for the upcoming playback.
+     * @return A {@link PlaybackQueue.Builder}.
+     */
     public Builder setQueue(List<Track> queue) {
       this.queue = queue;
       return this;
@@ -51,7 +71,7 @@ public class PlaybackQueue extends AbstractModelObject{
   }
 
   /**
-   * JsonUtil class for building {@link CurrentlyPlaying} instances.
+   * JsonUtil class for building {@link PlaybackQueue} instances.
    */
   public static final class JsonUtil extends AbstractModelObject.JsonUtil<PlaybackQueue> {
     public PlaybackQueue createModelObject(JsonObject jsonObject) {

--- a/src/main/java/se/michaelthelin/spotify/requests/data/player/AddItemToUsersPlaybackQueueRequest.java
+++ b/src/main/java/se/michaelthelin/spotify/requests/data/player/AddItemToUsersPlaybackQueueRequest.java
@@ -19,7 +19,7 @@ public class AddItemToUsersPlaybackQueueRequest extends AbstractDataRequest<Stri
    *
    * @param builder A {@link AddItemToUsersPlaybackQueueRequest.Builder}.
    */
-  private AddItemToUsersPlaybackQueueRequest(final Builder builder) {
+  AddItemToUsersPlaybackQueueRequest(final Builder builder) {
     super(builder);
   }
 

--- a/src/main/java/se/michaelthelin/spotify/requests/data/player/GetListOfTracksFromUsersPlaybackQueueRequest.java
+++ b/src/main/java/se/michaelthelin/spotify/requests/data/player/GetListOfTracksFromUsersPlaybackQueueRequest.java
@@ -3,23 +3,46 @@ package se.michaelthelin.spotify.requests.data.player;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.apache.hc.core5.http.ParseException;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
-import se.michaelthelin.spotify.model_objects.miscellaneous.PlaybackQueue;
+import se.michaelthelin.spotify.model_objects.special.PlaybackQueue;
 import se.michaelthelin.spotify.requests.data.AbstractDataRequest;
 
 import java.io.IOException;
 
+/**
+ * Get tracks from the current user’s playback queue.
+ * <p>
+ * Returns the tracks from the current user’s playback queue. Does not include the current playing track.
+ * <p>
+ *  The endpoint does not support paging since the queue is not expected to be large.
+ *  Therefore, the request will return a {@link PlaybackQueue} object including a List of {@link se.michaelthelin.spotify.model_objects.specification.Track}.
+ */
 @JsonDeserialize(builder = GetListOfTracksFromUsersPlaybackQueueRequest.Builder.class)
 public class GetListOfTracksFromUsersPlaybackQueueRequest extends AbstractDataRequest<PlaybackQueue> {
 
+  /**
+   * The private {@link GetListOfTracksFromUsersPlaybackQueueRequest} constructor.
+   *
+   * @param builder A {@link GetListOfTracksFromUsersPlaybackQueueRequest.Builder}.
+   */
   private GetListOfTracksFromUsersPlaybackQueueRequest(final Builder builder) {
     super(builder);
   }
 
+  /**
+   * Get an user's current playback queue.
+   *
+   * @return An {@link PlaybackQueue} object including a List of {@link se.michaelthelin.spotify.model_objects.specification.Track}.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
   @Override
   public PlaybackQueue execute() throws IOException, SpotifyWebApiException, ParseException {
     return new PlaybackQueue.JsonUtil().createModelObject(getJson());
   }
 
+  /**
+   * Builder class for building a {@link GetListOfTracksFromUsersPlaybackQueueRequest}.
+   */
   public static final class Builder extends AbstractDataRequest.Builder<PlaybackQueue, GetListOfTracksFromUsersPlaybackQueueRequest.Builder> {
 
     /**

--- a/src/main/java/se/michaelthelin/spotify/requests/data/player/GetListOfTracksFromUsersPlaybackQueueRequest.java
+++ b/src/main/java/se/michaelthelin/spotify/requests/data/player/GetListOfTracksFromUsersPlaybackQueueRequest.java
@@ -1,0 +1,54 @@
+package se.michaelthelin.spotify.requests.data.player;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.apache.hc.core5.http.ParseException;
+import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
+import se.michaelthelin.spotify.model_objects.miscellaneous.PlaybackQueue;
+import se.michaelthelin.spotify.requests.data.AbstractDataRequest;
+
+import java.io.IOException;
+
+@JsonDeserialize(builder = GetListOfTracksFromUsersPlaybackQueueRequest.Builder.class)
+public class GetListOfTracksFromUsersPlaybackQueueRequest extends AbstractDataRequest<PlaybackQueue> {
+
+  private GetListOfTracksFromUsersPlaybackQueueRequest(final Builder builder) {
+    super(builder);
+  }
+
+  @Override
+  public PlaybackQueue execute() throws IOException, SpotifyWebApiException, ParseException {
+    return new PlaybackQueue.JsonUtil().createModelObject(getJson());
+  }
+
+  public static final class Builder extends AbstractDataRequest.Builder<PlaybackQueue, GetListOfTracksFromUsersPlaybackQueueRequest.Builder> {
+
+    /**
+     * Create a new {@link GetListOfTracksFromUsersPlaybackQueueRequest.Builder}.
+     * <p>
+     * Your access token must have the {@code user-read-currently-playing} scope and/or the
+     * {@code user-read-playback-state} authorized in order to read information.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     * @see <a href="https://developer.spotify.com/web-api/using-scopes/">Spotify: Using Scopes</a>
+     */
+    public Builder(final String accessToken) {
+      super(accessToken);
+    }
+
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link GetListOfTracksFromUsersPlaybackQueueRequest}.
+     */
+    @Override
+    public GetListOfTracksFromUsersPlaybackQueueRequest build() {
+      setPath("/v1/me/player/queue");
+      return new GetListOfTracksFromUsersPlaybackQueueRequest(this);
+    }
+
+    @Override
+    protected GetListOfTracksFromUsersPlaybackQueueRequest.Builder self() {
+      return this;
+    }
+  }
+}

--- a/src/test/fixtures/requests/data/player/GetListOfTracksFromUsersPlaybackQueueRequest.json
+++ b/src/test/fixtures/requests/data/player/GetListOfTracksFromUsersPlaybackQueueRequest.json
@@ -1,0 +1,2213 @@
+{
+"currently_playing": {
+"album": {
+"album_type": "compilation",
+"total_tracks": 9,
+"available_markets": [
+"CA",
+"BR",
+"IT"
+],
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "2up3OPMp9Tb4dAKM2erWXQ",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"release_date": "1981-12",
+"release_date_precision": "year",
+"restrictions": {
+"reason": "market"
+},
+"type": "album",
+"uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+"album_group": "compilation",
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"name": "string",
+"type": "artist",
+"uri": "string"
+}
+]
+},
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"followers": {
+"href": "string",
+"total": 0
+},
+"genres": [
+"Prog rock",
+"Grunge"
+],
+"href": "string",
+"id": "string",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"popularity": 0,
+"type": "artist",
+"uri": "string"
+}
+],
+"available_markets": [
+"string"
+],
+"disc_number": 0,
+"duration_ms": 0,
+"explicit": true,
+"external_ids": {
+"isrc": "string",
+"ean": "string",
+"upc": "string"
+},
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"is_playable": true,
+"linked_from": {
+"album": {
+"album_type": "compilation",
+"total_tracks": 9,
+"available_markets": [
+"CA",
+"BR",
+"IT"
+],
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "2up3OPMp9Tb4dAKM2erWXQ",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"release_date": "1981-12",
+"release_date_precision": "year",
+"restrictions": {
+"reason": "market"
+},
+"type": "album",
+"uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+"album_group": "compilation",
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"name": "string",
+"type": "artist",
+"uri": "string"
+}
+]
+},
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"followers": {
+"href": "string",
+"total": 0
+},
+"genres": [
+"Prog rock",
+"Grunge"
+],
+"href": "string",
+"id": "string",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"popularity": 0,
+"type": "artist",
+"uri": "string"
+}
+],
+"available_markets": [
+"string"
+],
+"disc_number": 0,
+"duration_ms": 0,
+"explicit": true,
+"external_ids": {
+"isrc": "string",
+"ean": "string",
+"upc": "string"
+},
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"is_playable": true,
+"linked_from": {
+"album": {
+"album_type": "compilation",
+"total_tracks": 9,
+"available_markets": [
+"CA",
+"BR",
+"IT"
+],
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "2up3OPMp9Tb4dAKM2erWXQ",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"release_date": "1981-12",
+"release_date_precision": "year",
+"restrictions": {
+"reason": "market"
+},
+"type": "album",
+"uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+"album_group": "compilation",
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"name": "string",
+"type": "artist",
+"uri": "string"
+}
+]
+},
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"followers": {
+"href": "string",
+"total": 0
+},
+"genres": [
+"Prog rock",
+"Grunge"
+],
+"href": "string",
+"id": "string",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"popularity": 0,
+"type": "artist",
+"uri": "string"
+}
+],
+"available_markets": [
+"string"
+],
+"disc_number": 0,
+"duration_ms": 0,
+"explicit": true,
+"external_ids": {
+"isrc": "string",
+"ean": "string",
+"upc": "string"
+},
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"is_playable": true,
+"linked_from": {
+"album": {
+"album_type": "compilation",
+"total_tracks": 9,
+"available_markets": [
+"CA",
+"BR",
+"IT"
+],
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "2up3OPMp9Tb4dAKM2erWXQ",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"release_date": "1981-12",
+"release_date_precision": "year",
+"restrictions": {
+"reason": "market"
+},
+"type": "album",
+"uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+"album_group": "compilation",
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"name": "string",
+"type": "artist",
+"uri": "string"
+}
+]
+},
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"followers": {
+"href": "string",
+"total": 0
+},
+"genres": [
+"Prog rock",
+"Grunge"
+],
+"href": "string",
+"id": "string",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"popularity": 0,
+"type": "artist",
+"uri": "string"
+}
+],
+"available_markets": [
+"string"
+],
+"disc_number": 0,
+"duration_ms": 0,
+"explicit": true,
+"external_ids": {
+"isrc": "string",
+"ean": "string",
+"upc": "string"
+},
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"is_playable": true,
+"linked_from": {
+"album": {
+"album_type": "compilation",
+"total_tracks": 9,
+"available_markets": [
+"CA",
+"BR",
+"IT"
+],
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "2up3OPMp9Tb4dAKM2erWXQ",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"release_date": "1981-12",
+"release_date_precision": "year",
+"restrictions": {
+"reason": "market"
+},
+"type": "album",
+"uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+"album_group": "compilation",
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"name": "string",
+"type": "artist",
+"uri": "string"
+}
+]
+},
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"followers": {
+"href": "string",
+"total": 0
+},
+"genres": [
+"Prog rock",
+"Grunge"
+],
+"href": "string",
+"id": "string",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"popularity": 0,
+"type": "artist",
+"uri": "string"
+}
+],
+"available_markets": [
+"string"
+],
+"disc_number": 0,
+"duration_ms": 0,
+"explicit": true,
+"external_ids": {
+"isrc": "string",
+"ean": "string",
+"upc": "string"
+},
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"is_playable": true,
+"linked_from": {
+"album": {
+"album_type": "compilation",
+"total_tracks": 9,
+"available_markets": [
+"CA",
+"BR",
+"IT"
+],
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "2up3OPMp9Tb4dAKM2erWXQ",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"release_date": "1981-12",
+"release_date_precision": "year",
+"restrictions": {
+"reason": "market"
+},
+"type": "album",
+"uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+"album_group": "compilation",
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"name": "string",
+"type": "artist",
+"uri": "string"
+}
+]
+},
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"followers": {
+"href": "string",
+"total": 0
+},
+"genres": [
+"Prog rock",
+"Grunge"
+],
+"href": "string",
+"id": "string",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"popularity": 0,
+"type": "artist",
+"uri": "string"
+}
+],
+"available_markets": [
+"string"
+],
+"disc_number": 0,
+"duration_ms": 0,
+"explicit": true,
+"external_ids": {
+"isrc": "string",
+"ean": "string",
+"upc": "string"
+},
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"is_playable": true,
+"linked_from": {
+"album": {
+"album_type": "compilation",
+"total_tracks": 9,
+"available_markets": [
+"CA",
+"BR",
+"IT"
+],
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "2up3OPMp9Tb4dAKM2erWXQ",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"release_date": "1981-12",
+"release_date_precision": "year",
+"restrictions": {
+"reason": "market"
+},
+"type": "album",
+"uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+"album_group": "compilation",
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"name": "string",
+"type": "artist",
+"uri": "string"
+}
+]
+},
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"followers": {
+"href": "string",
+"total": 0
+},
+"genres": [
+"Prog rock",
+"Grunge"
+],
+"href": "string",
+"id": "string",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"popularity": 0,
+"type": "artist",
+"uri": "string"
+}
+],
+"available_markets": [
+"string"
+],
+"disc_number": 0,
+"duration_ms": 0,
+"explicit": true,
+"external_ids": {
+"isrc": "string",
+"ean": "string",
+"upc": "string"
+},
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"is_playable": true,
+"linked_from": {
+"album": {
+"album_type": "compilation",
+"total_tracks": 9,
+"available_markets": [
+"CA",
+"BR",
+"IT"
+],
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "2up3OPMp9Tb4dAKM2erWXQ",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"release_date": "1981-12",
+"release_date_precision": "year",
+"restrictions": {
+"reason": "market"
+},
+"type": "album",
+"uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+"album_group": "compilation",
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"name": "string",
+"type": "artist",
+"uri": "string"
+}
+]
+},
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"followers": {
+"href": "string",
+"total": 0
+},
+"genres": [
+"Prog rock",
+"Grunge"
+],
+"href": "string",
+"id": "string",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"popularity": 0,
+"type": "artist",
+"uri": "string"
+}
+],
+"available_markets": [
+"string"
+],
+"disc_number": 0,
+"duration_ms": 0,
+"explicit": true,
+"external_ids": {
+"isrc": "string",
+"ean": "string",
+"upc": "string"
+},
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"is_playable": true,
+"linked_from": {
+"album": {
+"album_type": "compilation",
+"total_tracks": 9,
+"available_markets": [
+"CA",
+"BR",
+"IT"
+],
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "2up3OPMp9Tb4dAKM2erWXQ",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"release_date": "1981-12",
+"release_date_precision": "year",
+"restrictions": {
+"reason": "market"
+},
+"type": "album",
+"uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+"album_group": "compilation",
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"name": "string",
+"type": "artist",
+"uri": "string"
+}
+]
+},
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"followers": {
+"href": "string",
+"total": 0
+},
+"genres": [
+"Prog rock",
+"Grunge"
+],
+"href": "string",
+"id": "string",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"popularity": 0,
+"type": "artist",
+"uri": "string"
+}
+],
+"available_markets": [
+"string"
+],
+"disc_number": 0,
+"duration_ms": 0,
+"explicit": true,
+"external_ids": {
+"isrc": "string",
+"ean": "string",
+"upc": "string"
+},
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"is_playable": true,
+"linked_from": {
+"album": {
+"album_type": "compilation",
+"total_tracks": 9,
+"available_markets": [
+"CA",
+"BR",
+"IT"
+],
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "2up3OPMp9Tb4dAKM2erWXQ",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"release_date": "1981-12",
+"release_date_precision": "year",
+"restrictions": {
+"reason": "market"
+},
+"type": "album",
+"uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+"album_group": "compilation",
+"artists": [
+{
+"external_urls": {},
+"href": "string",
+"id": "string",
+"name": "string",
+"type": "artist",
+"uri": "string"
+}
+]
+},
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"followers": {
+"href": "string",
+"total": 0
+},
+"genres": [
+"Prog rock",
+"Grunge"
+],
+"href": "string",
+"id": "string",
+"images": [
+{}
+],
+"name": "string",
+"popularity": 0,
+"type": "artist",
+"uri": "string"
+}
+],
+"available_markets": [
+"string"
+],
+"disc_number": 0,
+"duration_ms": 0,
+"explicit": true,
+"external_ids": {
+"isrc": "string",
+"ean": "string",
+"upc": "string"
+},
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"is_playable": true,
+"linked_from": {
+"album": {
+"album_type": "compilation",
+"total_tracks": 9,
+"available_markets": [
+"CA",
+"BR",
+"IT"
+],
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "2up3OPMp9Tb4dAKM2erWXQ",
+"images": [
+{}
+],
+"name": "string",
+"release_date": "1981-12",
+"release_date_precision": "year",
+"restrictions": {
+"reason": "market"
+},
+"type": "album",
+"uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+"album_group": "compilation",
+"artists": [
+{}
+]
+},
+"artists": [
+{
+"external_urls": {},
+"followers": {},
+"genres": [
+"Prog rock",
+"Grunge"
+],
+"href": "string",
+"id": "string",
+"images": [
+{}
+],
+"name": "string",
+"popularity": 0,
+"type": "artist",
+"uri": "string"
+}
+],
+"available_markets": [
+"string"
+],
+"disc_number": 0,
+"duration_ms": 0,
+"explicit": true,
+"external_ids": {
+"isrc": "string",
+"ean": "string",
+"upc": "string"
+},
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"is_playable": true,
+"linked_from": {
+"album": {
+"album_type": "compilation",
+"total_tracks": 9,
+"available_markets": [
+"CA",
+"BR",
+"IT"
+],
+"external_urls": {},
+"href": "string",
+"id": "2up3OPMp9Tb4dAKM2erWXQ",
+"images": [
+{}
+],
+"name": "string",
+"release_date": "1981-12",
+"release_date_precision": "year",
+"restrictions": {},
+"type": "album",
+"uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+"album_group": "compilation",
+"artists": [
+{}
+]
+},
+"artists": [
+{
+"genres": [],
+"images": []
+}
+],
+"available_markets": [
+"string"
+],
+"disc_number": 0,
+"duration_ms": 0,
+"explicit": true,
+"external_ids": {
+"isrc": "string",
+"ean": "string",
+"upc": "string"
+},
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"is_playable": true,
+"linked_from": {
+"album": {
+"available_markets": [],
+"images": [],
+"artists": []
+},
+"artists": [
+{}
+],
+"available_markets": [
+null
+],
+"disc_number": 0,
+"duration_ms": 0,
+"explicit": true,
+"external_ids": {},
+"external_urls": {},
+"href": "string",
+"id": "string",
+"is_playable": true,
+"linked_from": {
+"artists": [],
+"available_markets": []
+},
+"restrictions": {},
+"name": "string",
+"popularity": 0,
+"preview_url": "string",
+"track_number": 0,
+"type": "string",
+"uri": "string",
+"is_local": true
+},
+"restrictions": {
+"reason": "string"
+},
+"name": "string",
+"popularity": 0,
+"preview_url": "string",
+"track_number": 0,
+"type": "string",
+"uri": "string",
+"is_local": true
+},
+"restrictions": {
+"reason": "string"
+},
+"name": "string",
+"popularity": 0,
+"preview_url": "string",
+"track_number": 0,
+"type": "string",
+"uri": "string",
+"is_local": true
+},
+"restrictions": {
+"reason": "string"
+},
+"name": "string",
+"popularity": 0,
+"preview_url": "string",
+"track_number": 0,
+"type": "string",
+"uri": "string",
+"is_local": true
+},
+"restrictions": {
+"reason": "string"
+},
+"name": "string",
+"popularity": 0,
+"preview_url": "string",
+"track_number": 0,
+"type": "string",
+"uri": "string",
+"is_local": true
+},
+"restrictions": {
+"reason": "string"
+},
+"name": "string",
+"popularity": 0,
+"preview_url": "string",
+"track_number": 0,
+"type": "string",
+"uri": "string",
+"is_local": true
+},
+"restrictions": {
+"reason": "string"
+},
+"name": "string",
+"popularity": 0,
+"preview_url": "string",
+"track_number": 0,
+"type": "string",
+"uri": "string",
+"is_local": true
+},
+"restrictions": {
+"reason": "string"
+},
+"name": "string",
+"popularity": 0,
+"preview_url": "string",
+"track_number": 0,
+"type": "string",
+"uri": "string",
+"is_local": true
+},
+"restrictions": {
+"reason": "string"
+},
+"name": "string",
+"popularity": 0,
+"preview_url": "string",
+"track_number": 0,
+"type": "string",
+"uri": "string",
+"is_local": true
+},
+"restrictions": {
+"reason": "string"
+},
+"name": "string",
+"popularity": 0,
+"preview_url": "string",
+"track_number": 0,
+"type": "string",
+"uri": "string",
+"is_local": true
+},
+"restrictions": {
+"reason": "string"
+},
+"name": "string",
+"popularity": 0,
+"preview_url": "string",
+"track_number": 0,
+"type": "string",
+"uri": "string",
+"is_local": true
+},
+"restrictions": {
+"reason": "string"
+},
+"name": "string",
+"popularity": 0,
+"preview_url": "string",
+"track_number": 0,
+"type": "string",
+"uri": "string",
+"is_local": true
+},
+"restrictions": {
+"reason": "string"
+},
+"name": "string",
+"popularity": 0,
+"preview_url": "string",
+"track_number": 0,
+"type": "string",
+"uri": "string",
+"is_local": true
+},
+"queue": [
+{
+"album": {
+"album_type": "compilation",
+"total_tracks": 9,
+"available_markets": [
+"CA",
+"BR",
+"IT"
+],
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "2up3OPMp9Tb4dAKM2erWXQ",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"release_date": "1981-12",
+"release_date_precision": "year",
+"restrictions": {
+"reason": "market"
+},
+"type": "album",
+"uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+"album_group": "compilation",
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"name": "string",
+"type": "artist",
+"uri": "string"
+}
+]
+},
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"followers": {
+"href": "string",
+"total": 0
+},
+"genres": [
+"Prog rock",
+"Grunge"
+],
+"href": "string",
+"id": "string",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"popularity": 0,
+"type": "artist",
+"uri": "string"
+}
+],
+"available_markets": [
+"string"
+],
+"disc_number": 0,
+"duration_ms": 0,
+"explicit": true,
+"external_ids": {
+"isrc": "string",
+"ean": "string",
+"upc": "string"
+},
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"is_playable": true,
+"linked_from": {
+"album": {
+"album_type": "compilation",
+"total_tracks": 9,
+"available_markets": [
+"CA",
+"BR",
+"IT"
+],
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "2up3OPMp9Tb4dAKM2erWXQ",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"release_date": "1981-12",
+"release_date_precision": "year",
+"restrictions": {
+"reason": "market"
+},
+"type": "album",
+"uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+"album_group": "compilation",
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"name": "string",
+"type": "artist",
+"uri": "string"
+}
+]
+},
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"followers": {
+"href": "string",
+"total": 0
+},
+"genres": [
+"Prog rock",
+"Grunge"
+],
+"href": "string",
+"id": "string",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"popularity": 0,
+"type": "artist",
+"uri": "string"
+}
+],
+"available_markets": [
+"string"
+],
+"disc_number": 0,
+"duration_ms": 0,
+"explicit": true,
+"external_ids": {
+"isrc": "string",
+"ean": "string",
+"upc": "string"
+},
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"is_playable": true,
+"linked_from": {
+"album": {
+"album_type": "compilation",
+"total_tracks": 9,
+"available_markets": [
+"CA",
+"BR",
+"IT"
+],
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "2up3OPMp9Tb4dAKM2erWXQ",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"release_date": "1981-12",
+"release_date_precision": "year",
+"restrictions": {
+"reason": "market"
+},
+"type": "album",
+"uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+"album_group": "compilation",
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"name": "string",
+"type": "artist",
+"uri": "string"
+}
+]
+},
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"followers": {
+"href": "string",
+"total": 0
+},
+"genres": [
+"Prog rock",
+"Grunge"
+],
+"href": "string",
+"id": "string",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"popularity": 0,
+"type": "artist",
+"uri": "string"
+}
+],
+"available_markets": [
+"string"
+],
+"disc_number": 0,
+"duration_ms": 0,
+"explicit": true,
+"external_ids": {
+"isrc": "string",
+"ean": "string",
+"upc": "string"
+},
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"is_playable": true,
+"linked_from": {
+"album": {
+"album_type": "compilation",
+"total_tracks": 9,
+"available_markets": [
+"CA",
+"BR",
+"IT"
+],
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "2up3OPMp9Tb4dAKM2erWXQ",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"release_date": "1981-12",
+"release_date_precision": "year",
+"restrictions": {
+"reason": "market"
+},
+"type": "album",
+"uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+"album_group": "compilation",
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"name": "string",
+"type": "artist",
+"uri": "string"
+}
+]
+},
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"followers": {
+"href": "string",
+"total": 0
+},
+"genres": [
+"Prog rock",
+"Grunge"
+],
+"href": "string",
+"id": "string",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"popularity": 0,
+"type": "artist",
+"uri": "string"
+}
+],
+"available_markets": [
+"string"
+],
+"disc_number": 0,
+"duration_ms": 0,
+"explicit": true,
+"external_ids": {
+"isrc": "string",
+"ean": "string",
+"upc": "string"
+},
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"is_playable": true,
+"linked_from": {
+"album": {
+"album_type": "compilation",
+"total_tracks": 9,
+"available_markets": [
+"CA",
+"BR",
+"IT"
+],
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "2up3OPMp9Tb4dAKM2erWXQ",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"release_date": "1981-12",
+"release_date_precision": "year",
+"restrictions": {
+"reason": "market"
+},
+"type": "album",
+"uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+"album_group": "compilation",
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"name": "string",
+"type": "artist",
+"uri": "string"
+}
+]
+},
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"followers": {
+"href": "string",
+"total": 0
+},
+"genres": [
+"Prog rock",
+"Grunge"
+],
+"href": "string",
+"id": "string",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"popularity": 0,
+"type": "artist",
+"uri": "string"
+}
+],
+"available_markets": [
+"string"
+],
+"disc_number": 0,
+"duration_ms": 0,
+"explicit": true,
+"external_ids": {
+"isrc": "string",
+"ean": "string",
+"upc": "string"
+},
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"is_playable": true,
+"linked_from": {
+"album": {
+"album_type": "compilation",
+"total_tracks": 9,
+"available_markets": [
+"CA",
+"BR",
+"IT"
+],
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "2up3OPMp9Tb4dAKM2erWXQ",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"release_date": "1981-12",
+"release_date_precision": "year",
+"restrictions": {
+"reason": "market"
+},
+"type": "album",
+"uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+"album_group": "compilation",
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"name": "string",
+"type": "artist",
+"uri": "string"
+}
+]
+},
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"followers": {
+"href": "string",
+"total": 0
+},
+"genres": [
+"Prog rock",
+"Grunge"
+],
+"href": "string",
+"id": "string",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"popularity": 0,
+"type": "artist",
+"uri": "string"
+}
+],
+"available_markets": [
+"string"
+],
+"disc_number": 0,
+"duration_ms": 0,
+"explicit": true,
+"external_ids": {
+"isrc": "string",
+"ean": "string",
+"upc": "string"
+},
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"is_playable": true,
+"linked_from": {
+"album": {
+"album_type": "compilation",
+"total_tracks": 9,
+"available_markets": [
+"CA",
+"BR",
+"IT"
+],
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "2up3OPMp9Tb4dAKM2erWXQ",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"release_date": "1981-12",
+"release_date_precision": "year",
+"restrictions": {
+"reason": "market"
+},
+"type": "album",
+"uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+"album_group": "compilation",
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"name": "string",
+"type": "artist",
+"uri": "string"
+}
+]
+},
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"followers": {
+"href": "string",
+"total": 0
+},
+"genres": [
+"Prog rock",
+"Grunge"
+],
+"href": "string",
+"id": "string",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"popularity": 0,
+"type": "artist",
+"uri": "string"
+}
+],
+"available_markets": [
+"string"
+],
+"disc_number": 0,
+"duration_ms": 0,
+"explicit": true,
+"external_ids": {
+"isrc": "string",
+"ean": "string",
+"upc": "string"
+},
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"is_playable": true,
+"linked_from": {
+"album": {
+"album_type": "compilation",
+"total_tracks": 9,
+"available_markets": [
+"CA",
+"BR",
+"IT"
+],
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "2up3OPMp9Tb4dAKM2erWXQ",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"release_date": "1981-12",
+"release_date_precision": "year",
+"restrictions": {
+"reason": "market"
+},
+"type": "album",
+"uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+"album_group": "compilation",
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"name": "string",
+"type": "artist",
+"uri": "string"
+}
+]
+},
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"followers": {
+"href": "string",
+"total": 0
+},
+"genres": [
+"Prog rock",
+"Grunge"
+],
+"href": "string",
+"id": "string",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"popularity": 0,
+"type": "artist",
+"uri": "string"
+}
+],
+"available_markets": [
+"string"
+],
+"disc_number": 0,
+"duration_ms": 0,
+"explicit": true,
+"external_ids": {
+"isrc": "string",
+"ean": "string",
+"upc": "string"
+},
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"is_playable": true,
+"linked_from": {
+"album": {
+"album_type": "compilation",
+"total_tracks": 9,
+"available_markets": [
+"CA",
+"BR",
+"IT"
+],
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "2up3OPMp9Tb4dAKM2erWXQ",
+"images": [
+{
+"url": "https://i.scdn.co/image/ab67616d00001e02ff9ca10b55ce82ae553c8228\n",
+"height": 300,
+"width": 300
+}
+],
+"name": "string",
+"release_date": "1981-12",
+"release_date_precision": "year",
+"restrictions": {
+"reason": "market"
+},
+"type": "album",
+"uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+"album_group": "compilation",
+"artists": [
+{
+"external_urls": {},
+"href": "string",
+"id": "string",
+"name": "string",
+"type": "artist",
+"uri": "string"
+}
+]
+},
+"artists": [
+{
+"external_urls": {
+"spotify": "string"
+},
+"followers": {
+"href": "string",
+"total": 0
+},
+"genres": [
+"Prog rock",
+"Grunge"
+],
+"href": "string",
+"id": "string",
+"images": [
+{}
+],
+"name": "string",
+"popularity": 0,
+"type": "artist",
+"uri": "string"
+}
+],
+"available_markets": [
+"string"
+],
+"disc_number": 0,
+"duration_ms": 0,
+"explicit": true,
+"external_ids": {
+"isrc": "string",
+"ean": "string",
+"upc": "string"
+},
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"is_playable": true,
+"linked_from": {
+"album": {
+"album_type": "compilation",
+"total_tracks": 9,
+"available_markets": [
+"CA",
+"BR",
+"IT"
+],
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "2up3OPMp9Tb4dAKM2erWXQ",
+"images": [
+{}
+],
+"name": "string",
+"release_date": "1981-12",
+"release_date_precision": "year",
+"restrictions": {
+"reason": "market"
+},
+"type": "album",
+"uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+"album_group": "compilation",
+"artists": [
+{}
+]
+},
+"artists": [
+{
+"external_urls": {},
+"followers": {},
+"genres": [
+"Prog rock",
+"Grunge"
+],
+"href": "string",
+"id": "string",
+"images": [
+{}
+],
+"name": "string",
+"popularity": 0,
+"type": "artist",
+"uri": "string"
+}
+],
+"available_markets": [
+"string"
+],
+"disc_number": 0,
+"duration_ms": 0,
+"explicit": true,
+"external_ids": {
+"isrc": "string",
+"ean": "string",
+"upc": "string"
+},
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"is_playable": true,
+"linked_from": {
+"album": {
+"album_type": "compilation",
+"total_tracks": 9,
+"available_markets": [
+"CA",
+"BR",
+"IT"
+],
+"external_urls": {},
+"href": "string",
+"id": "2up3OPMp9Tb4dAKM2erWXQ",
+"images": [
+{}
+],
+"name": "string",
+"release_date": "1981-12",
+"release_date_precision": "year",
+"restrictions": {},
+"type": "album",
+"uri": "spotify:album:2up3OPMp9Tb4dAKM2erWXQ",
+"album_group": "compilation",
+"artists": [
+{}
+]
+},
+"artists": [
+{
+"genres": [],
+"images": []
+}
+],
+"available_markets": [
+"string"
+],
+"disc_number": 0,
+"duration_ms": 0,
+"explicit": true,
+"external_ids": {
+"isrc": "string",
+"ean": "string",
+"upc": "string"
+},
+"external_urls": {
+"spotify": "string"
+},
+"href": "string",
+"id": "string",
+"is_playable": true,
+"linked_from": {
+"album": {
+"available_markets": [],
+"images": [],
+"artists": []
+},
+"artists": [
+{}
+],
+"available_markets": [
+null
+],
+"disc_number": 0,
+"duration_ms": 0,
+"explicit": true,
+"external_ids": {},
+"external_urls": {},
+"href": "string",
+"id": "string",
+"is_playable": true,
+"linked_from": {
+"artists": [],
+"available_markets": []
+},
+"restrictions": {},
+"name": "string",
+"popularity": 0,
+"preview_url": "string",
+"track_number": 0,
+"type": "string",
+"uri": "string",
+"is_local": true
+},
+"restrictions": {
+"reason": "string"
+},
+"name": "string",
+"popularity": 0,
+"preview_url": "string",
+"track_number": 0,
+"type": "string",
+"uri": "string",
+"is_local": true
+},
+"restrictions": {
+"reason": "string"
+},
+"name": "string",
+"popularity": 0,
+"preview_url": "string",
+"track_number": 0,
+"type": "string",
+"uri": "string",
+"is_local": true
+},
+"restrictions": {
+"reason": "string"
+},
+"name": "string",
+"popularity": 0,
+"preview_url": "string",
+"track_number": 0,
+"type": "string",
+"uri": "string",
+"is_local": true
+},
+"restrictions": {
+"reason": "string"
+},
+"name": "string",
+"popularity": 0,
+"preview_url": "string",
+"track_number": 0,
+"type": "string",
+"uri": "string",
+"is_local": true
+},
+"restrictions": {
+"reason": "string"
+},
+"name": "string",
+"popularity": 0,
+"preview_url": "string",
+"track_number": 0,
+"type": "string",
+"uri": "string",
+"is_local": true
+},
+"restrictions": {
+"reason": "string"
+},
+"name": "string",
+"popularity": 0,
+"preview_url": "string",
+"track_number": 0,
+"type": "string",
+"uri": "string",
+"is_local": true
+},
+"restrictions": {
+"reason": "string"
+},
+"name": "string",
+"popularity": 0,
+"preview_url": "string",
+"track_number": 0,
+"type": "string",
+"uri": "string",
+"is_local": true
+},
+"restrictions": {
+"reason": "string"
+},
+"name": "string",
+"popularity": 0,
+"preview_url": "string",
+"track_number": 0,
+"type": "string",
+"uri": "string",
+"is_local": true
+},
+"restrictions": {
+"reason": "string"
+},
+"name": "string",
+"popularity": 0,
+"preview_url": "string",
+"track_number": 0,
+"type": "string",
+"uri": "string",
+"is_local": true
+},
+"restrictions": {
+"reason": "string"
+},
+"name": "string",
+"popularity": 0,
+"preview_url": "string",
+"track_number": 0,
+"type": "string",
+"uri": "string",
+"is_local": true
+},
+"restrictions": {
+"reason": "string"
+},
+"name": "string",
+"popularity": 0,
+"preview_url": "string",
+"track_number": 0,
+"type": "string",
+"uri": "string",
+"is_local": true
+}
+]
+}

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/GetListOfTracksFromUsersPlaybackQueueRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/GetListOfTracksFromUsersPlaybackQueueRequestTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
-import se.michaelthelin.spotify.model_objects.miscellaneous.PlaybackQueue;
+import se.michaelthelin.spotify.model_objects.special.PlaybackQueue;
 import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 
 import java.io.IOException;

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/GetListOfTracksFromUsersPlaybackQueueRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/GetListOfTracksFromUsersPlaybackQueueRequestTest.java
@@ -1,0 +1,57 @@
+package se.michaelthelin.spotify.requests.data.player;
+
+import org.apache.hc.core5.http.ParseException;
+import org.junit.jupiter.api.Test;
+import se.michaelthelin.spotify.ITest;
+import se.michaelthelin.spotify.TestUtil;
+import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
+import se.michaelthelin.spotify.model_objects.miscellaneous.PlaybackQueue;
+import se.michaelthelin.spotify.requests.data.AbstractDataTest;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class GetListOfTracksFromUsersPlaybackQueueRequestTest extends AbstractDataTest<PlaybackQueue> {
+
+  private final GetListOfTracksFromUsersPlaybackQueueRequest defaultRequest = ITest.SPOTIFY_API
+    .getListOfTracksFromUsersPlaybackQueue()
+    .setHttpManager(
+      TestUtil.MockedHttpManager.returningJson("requests/data/player/GetListOfTracksFromUsersPlaybackQueueRequest.json"))
+    .build();
+
+  public GetListOfTracksFromUsersPlaybackQueueRequestTest() throws Exception {
+    assertEquals("https://api.spotify.com:443/v1/me/player/queue",
+      defaultRequest.getUri().toString());
+  }
+
+
+  @Override
+  @Test
+  public void shouldComplyWithReference() {
+    assertHasAuthorizationHeader(defaultRequest);
+    assertEquals(
+      "https://api.spotify.com:443/v1/me/player/queue",
+      defaultRequest.getUri().toString());
+  }
+
+  @Override
+  @Test
+  public void shouldReturnDefault_sync() throws IOException, SpotifyWebApiException, ParseException {
+    shouldReturnDefault(defaultRequest.execute());
+  }
+
+  @Override
+  @Test
+  public void shouldReturnDefault_async() throws ExecutionException, InterruptedException {
+    shouldReturnDefault(defaultRequest.executeAsync().get());
+  }
+
+  @Override
+  public void shouldReturnDefault(PlaybackQueue type) {
+    assertNotNull(type.getQueue());
+    assertEquals(type.getQueue().size(), 1);
+    assertEquals(type.getQueue().get(0).getName(), "string");
+  }
+}


### PR DESCRIPTION
Spotify has added a new endpoint to receive the tracks in the queue that are next to be played. 
The current version doesn't have a request to call that endpoint.
Therefore the new request _GetCurrentUsersRecentlyPlayedTracksRequest_ is added in this pull request.