### PR TITLE
feat(device): add `supports_volume` field

### DIFF
--- a/src/main/java/se/michaelthelin/spotify/model_objects/miscellaneous/Device.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/miscellaneous/Device.java
@@ -17,9 +17,9 @@ public class Device extends AbstractModelObject {
   private final Boolean is_private_session;
   private final Boolean is_restricted;
   private final String name;
+  private final Boolean supports_volume;
   private final String type;
   private final Integer volume_percent;
-  private final Boolean supports_volume;
 
   private Device(final Builder builder) {
     super(builder);
@@ -29,9 +29,9 @@ public class Device extends AbstractModelObject {
     this.is_private_session = builder.is_private_session;
     this.is_restricted = builder.is_restricted;
     this.name = builder.name;
+    this.supports_volume = builder.supports_volume;
     this.type = builder.type;
     this.volume_percent = builder.volume_percent;
-    this.supports_volume = builder.supports_volume;
   }
 
   /**
@@ -80,6 +80,15 @@ public class Device extends AbstractModelObject {
   }
 
   /**
+   * Check whether the device can be used to set the volume.
+   *
+   * @return If this device can be used to set the volume.
+   */
+  public Boolean getSupports_volume() {
+    return supports_volume;
+  }
+
+  /**
    * Get the type of the device.
    *
    * @return Device type, such as "Computer", "Smartphone" or "Speaker".
@@ -97,19 +106,10 @@ public class Device extends AbstractModelObject {
     return volume_percent;
   }
 
-  /**
-   * Check whether the device can be used to set the volume.
-   *
-   * @return If this device can be used to set the volume.
-   */
-  public Boolean getSupports_volume() {
-    return supports_volume;
-  }
-
   @Override
   public String toString() {
     return "Device(id=" + id + ", is_active=" + is_active + ", is_private_session=" + is_private_session + ", is_restricted=" + is_restricted + ", name=" + name
-      + ", type=" + type + ", volume_percent=" + volume_percent + ", supports_volume=" + supports_volume + ")";
+      + ", supports_volume=" + supports_volume + ", type=" + type + ", volume_percent=" + volume_percent + ")";
   }
 
   @Override
@@ -126,9 +126,9 @@ public class Device extends AbstractModelObject {
     private Boolean is_private_session;
     private Boolean is_restricted;
     private String name;
+    private Boolean supports_volume;
     private String type;
     private Integer volume_percent;
-    private Boolean supports_volume;
 
     /**
      * The device ID setter.
@@ -186,6 +186,17 @@ public class Device extends AbstractModelObject {
     }
 
     /**
+     * The supports volume state setter.
+     *
+     * @param supports_volume If this device can be used to set the volume.
+     * @return A {@link Device.Builder}.
+     */
+    public Builder setSupports_volume(Boolean supports_volume) {
+      this.supports_volume = supports_volume;
+      return this;
+    }
+
+    /**
      * The device type setter.
      *
      * @param type Device type, such as "Computer", "Smartphone" or "Speaker".
@@ -204,17 +215,6 @@ public class Device extends AbstractModelObject {
      */
     public Builder setVolume_percent(Integer volume_percent) {
       this.volume_percent = volume_percent;
-      return this;
-    }
-
-    /**
-     * The supports volume state setter.
-     *
-     * @param supports_volume If this device can be used to set the volume.
-     * @return A {@link Device.Builder}.
-     */
-    public Builder setSupports_volume(Boolean supports_volume) {
-      this.supports_volume = supports_volume;
       return this;
     }
 
@@ -254,6 +254,10 @@ public class Device extends AbstractModelObject {
           hasAndNotNull(jsonObject, "name")
             ? jsonObject.get("name").getAsString()
             : null)
+        .setSupports_volume(
+          hasAndNotNull(jsonObject, "supports_volume")
+            ? jsonObject.get("supports_volume").getAsBoolean()
+            : null)
         .setType(
           hasAndNotNull(jsonObject, "type")
             ? jsonObject.get("type").getAsString()
@@ -261,10 +265,6 @@ public class Device extends AbstractModelObject {
         .setVolume_percent(
           hasAndNotNull(jsonObject, "volume_percent")
             ? jsonObject.get("volume_percent").getAsInt()
-            : null)
-        .setSupports_volume(
-          hasAndNotNull(jsonObject, "supports_volume")
-            ? jsonObject.get("supports_volume").getAsBoolean()
             : null)
         .build();
     }

--- a/src/main/java/se/michaelthelin/spotify/model_objects/miscellaneous/Device.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/miscellaneous/Device.java
@@ -19,6 +19,7 @@ public class Device extends AbstractModelObject {
   private final String name;
   private final String type;
   private final Integer volume_percent;
+  private final Boolean supports_volume;
 
   private Device(final Builder builder) {
     super(builder);
@@ -30,6 +31,7 @@ public class Device extends AbstractModelObject {
     this.name = builder.name;
     this.type = builder.type;
     this.volume_percent = builder.volume_percent;
+    this.supports_volume = builder.supports_volume;
   }
 
   /**
@@ -95,10 +97,19 @@ public class Device extends AbstractModelObject {
     return volume_percent;
   }
 
+  /**
+   * Check whether the device can be used to set the volume.
+   *
+   * @return If this device can be used to set the volume.
+   */
+  public Boolean getSupports_volume() {
+    return supports_volume;
+  }
+
   @Override
   public String toString() {
     return "Device(id=" + id + ", is_active=" + is_active + ", is_private_session=" + is_private_session + ", is_restricted=" + is_restricted + ", name=" + name
-        + ", type=" + type + ", volume_percent=" + volume_percent + ")";
+      + ", type=" + type + ", volume_percent=" + volume_percent + ", supports_volume=" + supports_volume + ")";
   }
 
   @Override
@@ -117,6 +128,7 @@ public class Device extends AbstractModelObject {
     private String name;
     private String type;
     private Integer volume_percent;
+    private Boolean supports_volume;
 
     /**
      * The device ID setter.
@@ -195,6 +207,17 @@ public class Device extends AbstractModelObject {
       return this;
     }
 
+    /**
+     * The supports volume state setter.
+     *
+     * @param supports_volume If this device can be used to set the volume.
+     * @return A {@link Device.Builder}.
+     */
+    public Builder setSupports_volume(Boolean supports_volume) {
+      this.supports_volume = supports_volume;
+      return this;
+    }
+
     @Override
     public Device build() {
       return new Device(this);
@@ -238,6 +261,10 @@ public class Device extends AbstractModelObject {
         .setVolume_percent(
           hasAndNotNull(jsonObject, "volume_percent")
             ? jsonObject.get("volume_percent").getAsInt()
+            : null)
+        .setSupports_volume(
+          hasAndNotNull(jsonObject, "supports_volume")
+            ? jsonObject.get("supports_volume").getAsBoolean()
             : null)
         .build();
     }

--- a/src/test/fixtures/requests/data/player/GetUsersAvailableDevices.json
+++ b/src/test/fixtures/requests/data/player/GetUsersAvailableDevices.json
@@ -7,7 +7,18 @@
       "is_restricted": false,
       "name": "My fridge",
       "type": "Computer",
-      "volume_percent": 100
+      "volume_percent": 100,
+      "supports_volume": true
+    },
+    {
+      "id": "dc96ab03e8ecad17a70945b000acfef7591cd34e",
+      "is_active": false,
+      "is_private_session": false,
+      "is_restricted": false,
+      "name": "My Smartphone",
+      "type": "Smartphone",
+      "volume_percent": 100,
+      "supports_volume": false
     }
   ]
 }

--- a/src/test/java/se/michaelthelin/spotify/requests/data/player/GetUsersAvailableDevicesTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/player/GetUsersAvailableDevicesTest.java
@@ -11,7 +11,7 @@ import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class GetUsersAvailableDevicesTest extends AbstractDataTest<Device[]> {
   private final GetUsersAvailableDevicesRequest defaultRequest = ITest.SPOTIFY_API
@@ -51,8 +51,29 @@ public class GetUsersAvailableDevicesTest extends AbstractDataTest<Device[]> {
 
   public void shouldReturnDefault(final Device[] devices) {
     assertEquals(
-      1,
+      2,
       devices.length);
+
+    Device computerDevice = devices[0];
+    Device smartPhoneDevice = devices[1];
+
+    assertEquals(computerDevice.getId(), "5fbb3ba6aa454b5534c4ba43a8c7e8e45a63ad0e");
+    assertFalse(computerDevice.getIs_active());
+    assertFalse(computerDevice.getIs_private_session());
+    assertFalse(computerDevice.getIs_restricted());
+    assertEquals(computerDevice.getName(), "My fridge");
+    assertEquals(computerDevice.getType(), "Computer");
+    assertEquals(computerDevice.getVolume_percent(), 100);
+    assertTrue(computerDevice.getSupports_volume());
+
+    assertEquals(smartPhoneDevice.getId(), "dc96ab03e8ecad17a70945b000acfef7591cd34e");
+    assertFalse(smartPhoneDevice.getIs_active());
+    assertFalse(smartPhoneDevice.getIs_private_session());
+    assertFalse(smartPhoneDevice.getIs_restricted());
+    assertEquals(smartPhoneDevice.getName(), "My Smartphone");
+    assertEquals(smartPhoneDevice.getType(), "Smartphone");
+    assertEquals(smartPhoneDevice.getVolume_percent(), 100);
+    assertFalse(smartPhoneDevice.getSupports_volume());
   }
 
   @Test


### PR DESCRIPTION
Adding the "supports_volume" field in Device.java

https://developer.spotify.com/documentation/web-api/reference/get-a-users-available-devices