### PR TITLE
feat: add 4 episode endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ access token only once, after which it becomes invalid.
   - [Remove User's Saved Tracks](examples/data/library/RemoveUsersSavedTracksExample.java)
   - [Save Albums for Current User](examples/data/library/SaveAlbumsForCurrentUserExample.java)
   - [Save Shows for Current User](examples/data/library/SaveShowsForCurrentUserExample.java)
+  - [Save Episodes for Current User](examples/data/library/SaveEpisodesForCurrentUserExample.java)
   - [Save Tracks for User](examples/data/library/SaveTracksForUserExample.java)
 
 

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ access token only once, after which it becomes invalid.
   - [Get User's Saved Tracks](examples/data/library/GetUsersSavedTracksExample.java)
   - [Remove Albums for Current User](examples/data/library/RemoveAlbumsForCurrentUserExample.java)
   - [Remove User's Saved Shows](examples/data/library/RemoveUsersSavedShowsExample.java)
+  - [Remove User's Saved Episodes](examples/data/library/RemoveUsersSavedEpisodesExample.java)
   - [Remove User's Saved Tracks](examples/data/library/RemoveUsersSavedTracksExample.java)
   - [Save Albums for Current User](examples/data/library/SaveAlbumsForCurrentUserExample.java)
   - [Save Shows for Current User](examples/data/library/SaveShowsForCurrentUserExample.java)

--- a/README.md
+++ b/README.md
@@ -264,20 +264,20 @@ access token only once, after which it becomes invalid.
 
 - **Library**
   - [Check User's Saved Albums](examples/data/library/CheckUsersSavedAlbumsExample.java)
-  - [Check User's Saved Shows](examples/data/library/CheckUsersSavedShowsExample.java)
   - [Check User's Saved Episodes](examples/data/library/CheckUsersSavedEpisodesExample.java)
+  - [Check User's Saved Shows](examples/data/library/CheckUsersSavedShowsExample.java)
   - [Check User's Saved Tracks](examples/data/library/CheckUsersSavedTracksExample.java)
   - [Get Current User's Saved Albums](examples/data/library/GetCurrentUsersSavedAlbumsExample.java)
-  - [Get User's Saved Shows](examples/data/library/GetUsersSavedShowsExample.java)
   - [Get User's Saved Episodes](examples/data/library/GetUsersSavedEpisodesExample.java)
+  - [Get User's Saved Shows](examples/data/library/GetUsersSavedShowsExample.java)
   - [Get User's Saved Tracks](examples/data/library/GetUsersSavedTracksExample.java)
   - [Remove Albums for Current User](examples/data/library/RemoveAlbumsForCurrentUserExample.java)
-  - [Remove User's Saved Shows](examples/data/library/RemoveUsersSavedShowsExample.java)
   - [Remove User's Saved Episodes](examples/data/library/RemoveUsersSavedEpisodesExample.java)
+  - [Remove User's Saved Shows](examples/data/library/RemoveUsersSavedShowsExample.java)
   - [Remove User's Saved Tracks](examples/data/library/RemoveUsersSavedTracksExample.java)
   - [Save Albums for Current User](examples/data/library/SaveAlbumsForCurrentUserExample.java)
-  - [Save Shows for Current User](examples/data/library/SaveShowsForCurrentUserExample.java)
   - [Save Episodes for Current User](examples/data/library/SaveEpisodesForCurrentUserExample.java)
+  - [Save Shows for Current User](examples/data/library/SaveShowsForCurrentUserExample.java)
   - [Save Tracks for User](examples/data/library/SaveTracksForUserExample.java)
 
 

--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ access token only once, after which it becomes invalid.
 - **Library**
   - [Check User's Saved Albums](examples/data/library/CheckUsersSavedAlbumsExample.java)
   - [Check User's Saved Shows](examples/data/library/CheckUsersSavedShowsExample.java)
+  - [Check User's Saved Episodes](examples/data/library/CheckUsersSavedEpisodesExample.java)
   - [Check User's Saved Tracks](examples/data/library/CheckUsersSavedTracksExample.java)
   - [Get Current User's Saved Albums](examples/data/library/GetCurrentUsersSavedAlbumsExample.java)
   - [Get User's Saved Shows](examples/data/library/GetUsersSavedShowsExample.java)

--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ access token only once, after which it becomes invalid.
   - [Check User's Saved Tracks](examples/data/library/CheckUsersSavedTracksExample.java)
   - [Get Current User's Saved Albums](examples/data/library/GetCurrentUsersSavedAlbumsExample.java)
   - [Get User's Saved Shows](examples/data/library/GetUsersSavedShowsExample.java)
+  - [Get User's Saved Episodes](examples/data/library/GetUsersSavedEpisodesExample.java)
   - [Get User's Saved Tracks](examples/data/library/GetUsersSavedTracksExample.java)
   - [Remove Albums for Current User](examples/data/library/RemoveAlbumsForCurrentUserExample.java)
   - [Remove User's Saved Shows](examples/data/library/RemoveUsersSavedShowsExample.java)

--- a/examples/data/library/CheckUsersSavedEpisodesExample.java
+++ b/examples/data/library/CheckUsersSavedEpisodesExample.java
@@ -1,0 +1,54 @@
+package data.library;
+
+import se.michaelthelin.spotify.SpotifyApi;
+import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
+import se.michaelthelin.spotify.requests.data.library.CheckUsersSavedEpisodesRequest;
+import org.apache.hc.core5.http.ParseException;
+
+import java.io.IOException;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+public class CheckUsersSavedEpisodesExample {
+  private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
+  private static final String[] ids = new String[]{"4GI3dxEafwap1sFiTGPKd1"};
+
+  private static final SpotifyApi spotifyApi = new SpotifyApi.Builder()
+    .setAccessToken(accessToken)
+    .build();
+  private static final CheckUsersSavedEpisodesRequest checkUsersSavedEpisodesRequest = spotifyApi.checkUsersSavedEpisodes(ids)
+    .build();
+
+  public static void checkUsersSavedEpisodes_Sync() {
+    try {
+      final Boolean[] booleans = checkUsersSavedEpisodesRequest.execute();
+
+      System.out.println("Length: " + booleans.length);
+    } catch (IOException | SpotifyWebApiException | ParseException e) {
+      System.out.println("Error: " + e.getMessage());
+    }
+  }
+
+  public static void checkUsersSavedEpisodes_Async() {
+    try {
+      final CompletableFuture<Boolean[]> booleansFuture = checkUsersSavedEpisodesRequest.executeAsync();
+
+      // Thread free to do other tasks...
+
+      // Example Only. Never block in production code.
+      final Boolean[] booleans = booleansFuture.join();
+
+      System.out.println("Length: " + booleans.length);
+    } catch (CompletionException e) {
+      System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
+    }
+  }
+
+  public static void main(String[] args) {
+    checkUsersSavedEpisodes_Sync();
+    checkUsersSavedEpisodes_Async();
+  }
+}

--- a/examples/data/library/GetUsersSavedEpisodesExample.java
+++ b/examples/data/library/GetUsersSavedEpisodesExample.java
@@ -1,0 +1,58 @@
+package data.library;
+
+import se.michaelthelin.spotify.SpotifyApi;
+import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
+import se.michaelthelin.spotify.model_objects.specification.Paging;
+import se.michaelthelin.spotify.model_objects.specification.SavedEpisode;
+import se.michaelthelin.spotify.requests.data.library.GetUsersSavedEpisodesRequest;
+import org.apache.hc.core5.http.ParseException;
+
+import java.io.IOException;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+public class GetUsersSavedEpisodesExample {
+  private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
+
+  private static final SpotifyApi spotifyApi = new SpotifyApi.Builder()
+    .setAccessToken(accessToken)
+    .build();
+  private static final GetUsersSavedEpisodesRequest getUsersSavedEpisodesRequest = spotifyApi.getUsersSavedEpisodes()
+//          .limit(10)
+//          .offset(0)
+//          .market(CountryCode.SE)
+    .build();
+
+  public static void getUsersSavedEpisodes_Sync() {
+    try {
+      final Paging<SavedEpisode> savedEpisodePaging = getUsersSavedEpisodesRequest.execute();
+
+      System.out.println("Total: " + savedEpisodePaging.getTotal());
+    } catch (IOException | SpotifyWebApiException | ParseException e) {
+      System.out.println("Error: " + e.getMessage());
+    }
+  }
+
+  public static void getUsersSavedEpisodes_Async() {
+    try {
+      final CompletableFuture<Paging<SavedEpisode>> pagingFuture = getUsersSavedEpisodesRequest.executeAsync();
+
+      // Thread free to do other tasks...
+
+      // Example Only. Never block in production code.
+      final Paging<SavedEpisode> savedEpisodePaging = pagingFuture.join();
+
+      System.out.println("Total: " + savedEpisodePaging.getTotal());
+    } catch (CompletionException e) {
+      System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
+    }
+  }
+
+  public static void main(String[] args) {
+    getUsersSavedEpisodes_Sync();
+    getUsersSavedEpisodes_Async();
+  }
+}

--- a/examples/data/library/RemoveUsersSavedEpisodesExample.java
+++ b/examples/data/library/RemoveUsersSavedEpisodesExample.java
@@ -1,0 +1,55 @@
+package data.library;
+
+import se.michaelthelin.spotify.SpotifyApi;
+import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
+import se.michaelthelin.spotify.requests.data.library.RemoveUsersSavedEpisodesRequest;
+import org.apache.hc.core5.http.ParseException;
+
+import java.io.IOException;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+public class RemoveUsersSavedEpisodesExample {
+  private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
+  private static final String[] ids = new String[]{"4GI3dxEafwap1sFiTGPKd1"};
+
+  private static final SpotifyApi spotifyApi = new SpotifyApi.Builder()
+    .setAccessToken(accessToken)
+    .build();
+  private static final RemoveUsersSavedEpisodesRequest removeUsersSavedEpisodesRequest = spotifyApi
+    .removeUsersSavedEpisodes(ids)
+    .build();
+
+  public static void removeUsersSavedEpisodes_Sync() {
+    try {
+      final String string = removeUsersSavedEpisodesRequest.execute();
+
+      System.out.println("Null: " + string);
+    } catch (IOException | SpotifyWebApiException | ParseException e) {
+      System.out.println("Error: " + e.getMessage());
+    }
+  }
+
+  public static void removeUsersSavedEpisodes_Async() {
+    try {
+      final CompletableFuture<String> stringFuture = removeUsersSavedEpisodesRequest.executeAsync();
+
+      // Thread free to do other tasks...
+
+      // Example Only. Never block in production code.
+      final String string = stringFuture.join();
+
+      System.out.println("Null: " + string);
+    } catch (CompletionException e) {
+      System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
+    }
+  }
+
+  public static void main(String[] args) {
+    removeUsersSavedEpisodes_Sync();
+    removeUsersSavedEpisodes_Async();
+  }
+}

--- a/examples/data/library/SaveEpisodesForCurrentUserExample.java
+++ b/examples/data/library/SaveEpisodesForCurrentUserExample.java
@@ -1,0 +1,55 @@
+package data.library;
+
+import se.michaelthelin.spotify.SpotifyApi;
+import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
+import se.michaelthelin.spotify.requests.data.library.SaveEpisodesForCurrentUserRequest;
+import org.apache.hc.core5.http.ParseException;
+
+import java.io.IOException;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+public class SaveEpisodesForCurrentUserExample {
+  private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
+  private static final String[] ids = new String[]{"4GI3dxEafwap1sFiTGPKd1"};
+
+  private static final SpotifyApi spotifyApi = new SpotifyApi.Builder()
+    .setAccessToken(accessToken)
+    .build();
+  private static final SaveEpisodesForCurrentUserRequest saveEpisodesForCurrentUserRequest = spotifyApi
+    .saveEpisodesForCurrentUser(ids)
+    .build();
+
+  public static void saveEpisodesForCurrentUser_Sync() {
+    try {
+      final String string = saveEpisodesForCurrentUserRequest.execute();
+
+      System.out.println("Null: " + string);
+    } catch (IOException | SpotifyWebApiException | ParseException e) {
+      System.out.println("Error: " + e.getMessage());
+    }
+  }
+
+  public static void saveEpisodesForCurrentUser_Async() {
+    try {
+      final CompletableFuture<String> stringFuture = saveEpisodesForCurrentUserRequest.executeAsync();
+
+      // Thread free to do other tasks...
+
+      // Example Only. Never block in production code.
+      final String string = stringFuture.join();
+
+      System.out.println("Null: " + string);
+    } catch (CompletionException e) {
+      System.out.println("Error: " + e.getCause().getMessage());
+    } catch (CancellationException e) {
+      System.out.println("Async operation cancelled.");
+    }
+  }
+
+  public static void main(String[] args) {
+    saveEpisodesForCurrentUser_Sync();
+    saveEpisodesForCurrentUser_Async();
+  }
+}

--- a/src/main/java/se/michaelthelin/spotify/SpotifyApi.java
+++ b/src/main/java/se/michaelthelin/spotify/SpotifyApi.java
@@ -987,6 +987,17 @@ public class SpotifyApi {
   }
 
   /**
+   * Get a list of the episodes saved in the current Spotify user's library.
+   *
+   * @return A {@link GetUsersSavedEpisodesRequest.Builder}.
+   * @apiNote This endpoint is in <b>beta</b> and could change without warning.
+   */
+  public GetUsersSavedEpisodesRequest.Builder getUsersSavedEpisodes() {
+    return new GetUsersSavedEpisodesRequest.Builder(accessToken)
+      .setDefaults(httpManager, scheme, host, port);
+  }
+
+  /**
    * Get an user's "Your Music" tracks.
    *
    * @return A {@link GetUsersSavedTracksRequest.Builder}.

--- a/src/main/java/se/michaelthelin/spotify/SpotifyApi.java
+++ b/src/main/java/se/michaelthelin/spotify/SpotifyApi.java
@@ -1060,6 +1060,34 @@ public class SpotifyApi {
   }
 
   /**
+   * Remove one or more episodes from the current user's library.
+   *
+   * @param ids The Spotify IDs for the episodes to be removed. Maximum: 50 IDs.
+   * @return A {@link RemoveUsersSavedEpisodesRequest.Builder}.
+   * @see <a href="https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids">Spotify: URLs &amp; IDs</a>
+   * @apiNote This endpoint is in <b>beta</b> and could change without warning.
+   */
+  public RemoveUsersSavedEpisodesRequest.Builder removeUsersSavedEpisodes(String... ids) {
+    return new RemoveUsersSavedEpisodesRequest.Builder(accessToken)
+      .setDefaults(httpManager, scheme, host, port)
+      .ids(concat(ids, ','));
+  }
+
+  /**
+   * Remove one or more episodes from the current user's library.
+   *
+   * @param ids The Spotify IDs for the episodes to be removed. Maximum: 50 IDs.
+   * @return A {@link RemoveUsersSavedEpisodesRequest.Builder}.
+   * @see <a href="https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids">Spotify: URLs &amp; IDs</a>
+   * @apiNote This endpoint is in <b>beta</b> and could change without warning.
+   */
+  public RemoveUsersSavedEpisodesRequest.Builder removeUsersSavedEpisodes(JsonArray ids) {
+    return new RemoveUsersSavedEpisodesRequest.Builder(accessToken)
+      .setDefaults(httpManager, scheme, host, port)
+      .ids(ids);
+  }
+
+  /**
    * Remove a track if saved to the user's "Your Music" library.
    *
    * @param ids The track IDs to remove from the user's Your Music library. Maximum: 50 IDs.

--- a/src/main/java/se/michaelthelin/spotify/SpotifyApi.java
+++ b/src/main/java/se/michaelthelin/spotify/SpotifyApi.java
@@ -1138,6 +1138,34 @@ public class SpotifyApi {
   }
 
   /**
+   * Save one or more episodes to the current user's library.
+   *
+   * @param ids The episode IDs to add to the users library. Maximum: 50 IDs.
+   * @return A {@link SaveEpisodesForCurrentUserRequest.Builder}.
+   * @see <a href="https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids">Spotify: URLs &amp; IDs</a>
+   * @apiNote This endpoint is in <b>beta</b> and could change without warning.
+   */
+  public SaveEpisodesForCurrentUserRequest.Builder saveEpisodesForCurrentUser(String... ids) {
+    return new SaveEpisodesForCurrentUserRequest.Builder(accessToken)
+      .setDefaults(httpManager, scheme, host, port)
+      .ids(concat(ids, ','));
+  }
+
+  /**
+   * Save one or more episodes to the current user's library.
+   *
+   * @param ids The episode IDs to add to the users library. Maximum: 50 IDs.
+   * @return A {@link SaveEpisodesForCurrentUserRequest.Builder}.
+   * @see <a href="https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids">Spotify: URLs &amp; IDs</a>
+   * @apiNote This endpoint is in <b>beta</b> and could change without warning.
+   */
+  public SaveEpisodesForCurrentUserRequest.Builder saveEpisodesForCurrentUser(JsonArray ids) {
+    return new SaveEpisodesForCurrentUserRequest.Builder(accessToken)
+      .setDefaults(httpManager, scheme, host, port)
+      .ids(ids);
+  }
+
+  /**
    * Save tracks in the user's "Your Music" library.
    *
    * @param ids The track IDs to add to the user's library. Maximum: 50 IDs.

--- a/src/main/java/se/michaelthelin/spotify/SpotifyApi.java
+++ b/src/main/java/se/michaelthelin/spotify/SpotifyApi.java
@@ -954,6 +954,20 @@ public class SpotifyApi {
   }
 
   /**
+   * Check if one or more episodes is already saved in the current Spotify user's 'Your Episodes' library.
+   *
+   * @param ids The episode IDs to check for in the user's 'Your Episodes' library. Maximum: 50 IDs.
+   * @return A {@link CheckUsersSavedEpisodesRequest.Builder}.
+   * @see <a href="https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids">Spotify: URLs &amp; IDs</a>
+   * @apiNote This endpoint is in <b>beta</b> and could change without warning.
+   */
+  public CheckUsersSavedEpisodesRequest.Builder checkUsersSavedEpisodes(String... ids) {
+    return new CheckUsersSavedEpisodesRequest.Builder(accessToken)
+      .setDefaults(httpManager, scheme, host, port)
+      .ids(concat(ids, ','));
+  }
+
+  /**
    * Check if a track is saved in the user's "Your Music" library.
    *
    * @param ids The track IDs to check for in the user's Your Music library. Maximum: 50 IDs.

--- a/src/main/java/se/michaelthelin/spotify/model_objects/miscellaneous/SavedEpisode.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/miscellaneous/SavedEpisode.java
@@ -1,9 +1,10 @@
-package se.michaelthelin.spotify.model_objects.specification;
+package se.michaelthelin.spotify.model_objects.miscellaneous;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.gson.JsonObject;
 import se.michaelthelin.spotify.SpotifyApi;
 import se.michaelthelin.spotify.model_objects.AbstractModelObject;
+import se.michaelthelin.spotify.model_objects.specification.Episode;
 
 import java.text.ParseException;
 import java.util.Date;

--- a/src/main/java/se/michaelthelin/spotify/model_objects/specification/SavedEpisode.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/specification/SavedEpisode.java
@@ -1,0 +1,117 @@
+package se.michaelthelin.spotify.model_objects.specification;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.gson.JsonObject;
+import se.michaelthelin.spotify.SpotifyApi;
+import se.michaelthelin.spotify.model_objects.AbstractModelObject;
+
+import java.text.ParseException;
+import java.util.Date;
+import java.util.logging.Level;
+
+/**
+ * Retrieve information about saved episode object by building instances from this class.
+ */
+@JsonDeserialize(builder = SavedEpisode.Builder.class)
+public class SavedEpisode extends AbstractModelObject {
+  private final Date addedAt;
+  private final Episode episode;
+
+  private SavedEpisode(final SavedEpisode.Builder builder) {
+    super(builder);
+    this.addedAt = builder.addedAt;
+    this.episode = builder.episode;
+  }
+
+  /**
+   * Get the date, when the episode has been saved.
+   *
+   * @return The date and time the episode was saved.
+   */
+  public Date getAddedAt() {
+    return addedAt;
+  }
+
+  /**
+   * Get information about the episode from a saved episode object.
+   *
+   * @return Information about the episode.
+   */
+  public Episode getEpisode() {
+    return episode;
+  }
+
+  @Override
+  public String toString() {
+    return "SavedEpisode(addedAt=" + addedAt + ", episode=" + episode + ")";
+  }
+
+  @Override
+  public SavedEpisode.Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Builder class for building {@link SavedEpisode} instances.
+   */
+  public static final class Builder extends AbstractModelObject.Builder {
+    private Date addedAt;
+    private Episode episode;
+
+    /**
+     * Set the "added at" date of the saved episode to be built.
+     *
+     * @param addedAt The date and time the episode was saved.
+     * @return A {@link SavedEpisode.Builder}.
+     */
+    public SavedEpisode.Builder setAddedAt(Date addedAt) {
+      this.addedAt = addedAt;
+      return this;
+    }
+
+    /**
+     * Set the full episode object of the saved episode to be built.
+     *
+     * @param episode Information about the episode.
+     * @return A {@link SavedEpisode.Builder}.
+     */
+    public SavedEpisode.Builder setEpisode(Episode episode) {
+      this.episode = episode;
+      return this;
+    }
+
+    @Override
+    public SavedEpisode build() {
+      return new SavedEpisode(this);
+    }
+  }
+
+  /**
+   * JsonUtil class for building {@link SavedEpisode} instances.
+   */
+  public static final class JsonUtil extends AbstractModelObject.JsonUtil<SavedEpisode> {
+    @Override
+    public SavedEpisode createModelObject(JsonObject jsonObject) {
+      if (jsonObject == null || jsonObject.isJsonNull()) {
+        return null;
+      }
+
+      try {
+        return new Builder()
+          .setAddedAt(
+            hasAndNotNull(jsonObject, "added_at")
+              ? SpotifyApi.parseDefaultDate(jsonObject.get("added_at").getAsString())
+              : null)
+          .setEpisode(
+            hasAndNotNull(jsonObject, "episode")
+              ? new Episode.JsonUtil().createModelObject(
+              jsonObject.getAsJsonObject("episode"))
+              : null)
+          .build();
+      } catch (ParseException e) {
+        SpotifyApi.LOGGER.log(Level.SEVERE, e.getMessage());
+        return null;
+      }
+    }
+  }
+}

--- a/src/main/java/se/michaelthelin/spotify/requests/data/library/CheckUsersSavedEpisodesRequest.java
+++ b/src/main/java/se/michaelthelin/spotify/requests/data/library/CheckUsersSavedEpisodesRequest.java
@@ -1,0 +1,88 @@
+package se.michaelthelin.spotify.requests.data.library;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.gson.Gson;
+import com.google.gson.JsonParser;
+import org.apache.hc.core5.http.ParseException;
+import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
+import se.michaelthelin.spotify.requests.data.AbstractDataRequest;
+
+import java.io.IOException;
+
+/**
+ * Check if one or more episodes is already saved in the current Spotify user's 'Your Episodes' library.
+ */
+@JsonDeserialize(builder = CheckUsersSavedEpisodesRequest.Builder.class)
+public class CheckUsersSavedEpisodesRequest extends AbstractDataRequest<Boolean[]> {
+
+  /**
+   * The private {@link CheckUsersSavedEpisodesRequest} constructor.
+   *
+   * @param builder A {@link CheckUsersSavedEpisodesRequest.Builder}.
+   */
+  private CheckUsersSavedEpisodesRequest(final CheckUsersSavedEpisodesRequest.Builder builder) {
+    super(builder);
+  }
+
+  /**
+   * Check if one or more episodes is already saved in the current Spotify user's 'Your Episodes' library.
+   *
+   * @return Whether an episode is present in the current user's "Your Music" library.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
+  @Override
+  public Boolean[] execute() throws
+    IOException,
+    SpotifyWebApiException,
+    ParseException {
+    return new Gson().fromJson(JsonParser.parseString(getJson()).getAsJsonArray(), Boolean[].class);
+  }
+
+  /**
+   * Builder class for building a {@link CheckUsersSavedEpisodesRequest}.
+   */
+  public static final class Builder extends AbstractDataRequest.Builder<Boolean[], CheckUsersSavedEpisodesRequest.Builder> {
+
+    /**
+     * Create a new {@link CheckUsersSavedEpisodesRequest.Builder} instance.
+     * <p>
+     * The {@code user-library-read} scope must have been authorized by the user.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     * @see <a href="https://developer.spotify.com/documentation/web-api/concepts/scopes">Spotify: Scopes</a>
+     */
+    public Builder(final String accessToken) {
+      super(accessToken);
+    }
+
+    /**
+     * The episode IDs setter.
+     *
+     * @param ids Required. A comma-separated list of the Spotify IDs for the episodes. Maximum: 50 IDs.
+     * @return A {@link CheckUsersSavedEpisodesRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids">Spotify: URIs &amp; IDs</a>
+     */
+    public CheckUsersSavedEpisodesRequest.Builder ids(final String ids) {
+      assert (ids != null);
+      assert (ids.split(",").length <= 50);
+      return setQueryParameter("ids", ids);
+    }
+
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link CheckUsersSavedEpisodesRequest}.
+     */
+    @Override
+    public CheckUsersSavedEpisodesRequest build() {
+      setPath("/v1/me/episodes/contains");
+      return new CheckUsersSavedEpisodesRequest(this);
+    }
+
+    @Override
+    protected CheckUsersSavedEpisodesRequest.Builder self() {
+      return this;
+    }
+  }
+}

--- a/src/main/java/se/michaelthelin/spotify/requests/data/library/GetUsersSavedEpisodesRequest.java
+++ b/src/main/java/se/michaelthelin/spotify/requests/data/library/GetUsersSavedEpisodesRequest.java
@@ -5,7 +5,7 @@ import com.neovisionaries.i18n.CountryCode;
 import org.apache.hc.core5.http.ParseException;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.specification.Paging;
-import se.michaelthelin.spotify.model_objects.specification.SavedEpisode;
+import se.michaelthelin.spotify.model_objects.miscellaneous.SavedEpisode;
 import se.michaelthelin.spotify.requests.data.AbstractDataPagingRequest;
 import se.michaelthelin.spotify.requests.data.AbstractDataRequest;
 

--- a/src/main/java/se/michaelthelin/spotify/requests/data/library/GetUsersSavedEpisodesRequest.java
+++ b/src/main/java/se/michaelthelin/spotify/requests/data/library/GetUsersSavedEpisodesRequest.java
@@ -1,0 +1,118 @@
+package se.michaelthelin.spotify.requests.data.library;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.neovisionaries.i18n.CountryCode;
+import org.apache.hc.core5.http.ParseException;
+import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
+import se.michaelthelin.spotify.model_objects.specification.Paging;
+import se.michaelthelin.spotify.model_objects.specification.SavedEpisode;
+import se.michaelthelin.spotify.requests.data.AbstractDataPagingRequest;
+import se.michaelthelin.spotify.requests.data.AbstractDataRequest;
+
+import java.io.IOException;
+
+/**
+ * Get a list of the episodes saved in the current Spotify user's library.
+ */
+@JsonDeserialize(builder = GetUsersSavedEpisodesRequest.Builder.class)
+public class GetUsersSavedEpisodesRequest extends AbstractDataRequest<Paging<SavedEpisode>> {
+
+  /**
+   * The private {@link GetUsersSavedEpisodesRequest} constructor.
+   *
+   * @param builder A {@link GetUsersSavedEpisodesRequest.Builder}.
+   */
+  private GetUsersSavedEpisodesRequest(GetUsersSavedEpisodesRequest.Builder builder) {
+    super(builder);
+  }
+
+  /**
+   * Get a list of the current user’s saved episodes.
+   *
+   * @return A {@link SavedEpisode} paging object.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
+  @Override
+  public Paging<SavedEpisode> execute() throws
+    IOException,
+    SpotifyWebApiException,
+    ParseException {
+    return new SavedEpisode.JsonUtil().createModelObjectPaging(getJson());
+  }
+
+  /**
+   * Builder class for building a {@link GetUsersSavedEpisodesRequest}.
+   */
+  public static final class Builder extends AbstractDataPagingRequest.Builder<SavedEpisode, GetUsersSavedEpisodesRequest.Builder> {
+
+    /**
+     * Create a new {@link GetUsersSavedEpisodesRequest.Builder} instance.
+     * <p>
+     * The {@code user-library-read} scope must have been authorized by the user.
+     * Additionally, if the user has also authorized the {@code user-read-playback-position} scope,
+     * {@link se.michaelthelin.spotify.model_objects.specification.ResumePoint ResumePoint} gets set.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     * @see <a href="https://developer.spotify.com/documentation/web-api/concepts/scopes">Spotify: Scopes</a>
+     */
+    public Builder(final String accessToken) {
+      super(accessToken);
+    }
+
+    /**
+     * The limit setter.
+     *
+     * @param limit Optional. The maximum number of episodes to return. Default: 20. Minimum: 1. Maximum: 50.
+     * @return A {@link GetUsersSavedEpisodesRequest.Builder}.
+     */
+    @Override
+    public GetUsersSavedEpisodesRequest.Builder limit(final Integer limit) {
+      assert (1 <= limit && limit <= 50);
+      return setQueryParameter("limit", limit);
+    }
+
+    /**
+     * The offset setter.
+     *
+     * @param offset Optional. The index of the first episode to return. Default: 0 (i.e., the first object). Use with
+     *               {@link #limit(Integer)} to get the next set of objects.
+     * @return A {@link GetUsersSavedEpisodesRequest.Builder}.
+     */
+    @Override
+    public GetUsersSavedEpisodesRequest.Builder offset(final Integer offset) {
+      assert (offset >= 0);
+      return setQueryParameter("offset", offset);
+    }
+
+    /**
+     * The market country code setter.
+     *
+     * @param market Optional. An ISO 3166-1 alpha-2 country code. Provide this parameter if you want to apply
+     *               Track Relinking.
+     * @return A {@link GetCurrentUsersSavedAlbumsRequest.Builder}.
+     * @see <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">Wikipedia: ISO 3166-1 alpha-2 country codes</a>
+     * @see <a href="https://developer.spotify.com/documentation/web-api/concepts/track-relinking">Spotify: Track Relinking Guide</a>
+     */
+    public GetUsersSavedEpisodesRequest.Builder market(final CountryCode market) {
+      assert (market != null);
+      return setQueryParameter("market", market);
+    }
+
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link GetUsersSavedEpisodesRequest}.
+     */
+    @Override
+    public GetUsersSavedEpisodesRequest build() {
+      setPath("/v1/me/episodes");
+      return new GetUsersSavedEpisodesRequest(this);
+    }
+
+    @Override
+    protected GetUsersSavedEpisodesRequest.Builder self() {
+      return this;
+    }
+  }
+}

--- a/src/main/java/se/michaelthelin/spotify/requests/data/library/RemoveUsersSavedEpisodesRequest.java
+++ b/src/main/java/se/michaelthelin/spotify/requests/data/library/RemoveUsersSavedEpisodesRequest.java
@@ -1,0 +1,106 @@
+package se.michaelthelin.spotify.requests.data.library;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.gson.JsonArray;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.ParseException;
+import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
+import se.michaelthelin.spotify.requests.data.AbstractDataRequest;
+
+import java.io.IOException;
+
+/**
+ * Remove one or more episodes from the current user's library.
+ */
+@JsonDeserialize(builder = RemoveUsersSavedEpisodesRequest.Builder.class)
+public class RemoveUsersSavedEpisodesRequest extends AbstractDataRequest<String> {
+
+  /**
+   * The private {@link RemoveUsersSavedEpisodesRequest} constructor.
+   *
+   * @param builder A {@link RemoveUsersSavedEpisodesRequest.Builder}.
+   */
+  private RemoveUsersSavedEpisodesRequest(final RemoveUsersSavedEpisodesRequest.Builder builder) {
+    super(builder);
+  }
+
+  /**
+   * Remove one or more episodes from current Spotify user’s library.
+   *
+   * @return A string. <b>Note:</b> This endpoint doesn't return something in its response body.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
+  @Override
+  public String execute() throws
+    IOException,
+    SpotifyWebApiException,
+    ParseException {
+    return deleteJson();
+  }
+
+  /**
+   * Builder class for building a {@link RemoveUsersSavedEpisodesRequest}.
+   */
+  public static final class Builder extends AbstractDataRequest.Builder<String, RemoveUsersSavedEpisodesRequest.Builder> {
+
+    /**
+     * Create a new {@link RemoveUsersSavedEpisodesRequest.Builder} instance.
+     * <p>
+     * Modification of the current user's "Your Music" collection requires authorization of the
+     * {@code user-library-modify} scope.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     * @see <a href="https://developer.spotify.com/documentation/web-api/concepts/scopes">Spotify: Using Scopes</a>
+     */
+    public Builder(final String accessToken) {
+      super(accessToken);
+    }
+
+    /**
+     * The episode IDs setter.
+     *
+     * @param ids Optional. A comma-separated list of Spotify IDs for the episodes to be deleted from the user’s library. Maximum: 50 IDs.
+     * @return A {@link RemoveUsersSavedEpisodesRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids">Spotify: URIs &amp; IDs</a>
+     */
+    public RemoveUsersSavedEpisodesRequest.Builder ids(final String ids) {
+      assert (ids != null);
+      assert (ids.split(",").length <= 50);
+      return setQueryParameter("ids", ids);
+    }
+
+    /**
+     * The episode IDs setter.
+     * <p>
+     * <b>Note:</b> If the ids have already been set with {@link #ids(String)}, any ids added here will be ignored.
+     *
+     * @param ids Optional. A JSON array of Spotify IDs for the episodes to be deleted from the user’s library. Maximum: 50 IDs.
+     * @return A {@link RemoveUsersSavedEpisodesRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids">Spotify: URIs &amp; IDs</a>
+     */
+    public RemoveUsersSavedEpisodesRequest.Builder ids(final JsonArray ids) {
+      assert (ids != null);
+      assert (!ids.isJsonNull());
+      assert (ids.size() <= 50);
+      return setBodyParameter("ids", ids);
+    }
+
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link RemoveUsersSavedEpisodesRequest}.
+     */
+    @Override
+    public RemoveUsersSavedEpisodesRequest build() {
+      setContentType(ContentType.APPLICATION_JSON);
+      setPath("/v1/me/episodes");
+      return new RemoveUsersSavedEpisodesRequest(this);
+    }
+
+    @Override
+    protected RemoveUsersSavedEpisodesRequest.Builder self() {
+      return this;
+    }
+  }
+}

--- a/src/main/java/se/michaelthelin/spotify/requests/data/library/SaveEpisodesForCurrentUserRequest.java
+++ b/src/main/java/se/michaelthelin/spotify/requests/data/library/SaveEpisodesForCurrentUserRequest.java
@@ -1,0 +1,107 @@
+package se.michaelthelin.spotify.requests.data.library;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.gson.JsonArray;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.ParseException;
+import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
+import se.michaelthelin.spotify.requests.data.AbstractDataRequest;
+
+import java.io.IOException;
+
+/**
+ * Save one or more episodes to the current user's library.
+ */
+@JsonDeserialize(builder = SaveEpisodesForCurrentUserRequest.Builder.class)
+public class SaveEpisodesForCurrentUserRequest extends AbstractDataRequest<String> {
+
+  /**
+   * The private {@link SaveEpisodesForCurrentUserRequest} constructor.
+   *
+   * @param builder A {@link SaveEpisodesForCurrentUserRequest.Builder}.
+   */
+  private SaveEpisodesForCurrentUserRequest(final SaveEpisodesForCurrentUserRequest.Builder builder) {
+    super(builder);
+  }
+
+  /**
+   * Save one or more episodes.
+   *
+   * @return A string. <b>Note:</b> This endpoint doesn't return something in its response body.
+   * @throws IOException            In case of networking issues.
+   * @throws SpotifyWebApiException The Web API returned an error further specified in this exception's root cause.
+   */
+  @Override
+  public String execute() throws
+    IOException,
+    SpotifyWebApiException,
+    ParseException {
+    return putJson();
+  }
+
+  /**
+   * Builder class for building a {@link SaveEpisodesForCurrentUserRequest}.
+   */
+  public static final class Builder extends AbstractDataRequest.Builder<String, SaveEpisodesForCurrentUserRequest.Builder> {
+
+    /**
+     * Create a new {@link SaveEpisodesForCurrentUserRequest.Builder} instance.
+     * <p>
+     * Modification of the current user's "Your Music" collection requires authorization of the
+     * {@code user-library-modify} scope.
+     *
+     * @param accessToken Required. A valid access token from the Spotify Accounts service.
+     * @see <a href="https://developer.spotify.com/documentation/web-api/concepts/scopes">Spotify: Scopes</a>
+     */
+    public Builder(String accessToken) {
+      super(accessToken);
+    }
+
+    /**
+     * The episode IDs setter.
+     *
+     * @param ids Optional. A comma-separated list of Spotify IDs for the episodes to be added to the user’s library.
+     * @return A {@link SaveEpisodesForCurrentUserRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids">Spotify: URIs &amp; IDs</a>
+     */
+    public SaveEpisodesForCurrentUserRequest.Builder ids(final String ids) {
+      assert (ids != null);
+      assert (ids.split(",").length <= 50);
+      return setQueryParameter("ids", ids);
+    }
+
+    /**
+     * The episode IDs setter.
+     * <p>
+     * <b>Note:</b> If the ids have already been set with {@link #ids(String)}, any ids added here will be ignored.
+     *
+     * @param ids Optional. A JSON array of Spotify IDs for the episodes to be added to the user’s library.
+     * @return A {@link SaveEpisodesForCurrentUserRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids">Spotify: URIs &amp; IDs</a>
+     */
+    public SaveEpisodesForCurrentUserRequest.Builder ids(final JsonArray ids) {
+      assert (ids != null);
+      assert (!ids.isJsonNull());
+      assert (ids.size() <= 50);
+      return setBodyParameter("ids", ids);
+    }
+
+    /**
+     * The request build method.
+     *
+     * @return A custom {@link SaveEpisodesForCurrentUserRequest}.
+     */
+    @Override
+    public SaveEpisodesForCurrentUserRequest build() {
+      setContentType(ContentType.APPLICATION_JSON);
+      setPath("/v1/me/episodes");
+      return new SaveEpisodesForCurrentUserRequest(this);
+    }
+
+    @Override
+    protected SaveEpisodesForCurrentUserRequest.Builder self() {
+      return this;
+    }
+  }
+
+}

--- a/src/test/fixtures/requests/data/library/CheckUsersSavedEpisodesRequest.json
+++ b/src/test/fixtures/requests/data/library/CheckUsersSavedEpisodesRequest.json
@@ -1,0 +1,4 @@
+[
+  true,
+  false
+]

--- a/src/test/fixtures/requests/data/library/GetUsersSavedEpisodesRequest.json
+++ b/src/test/fixtures/requests/data/library/GetUsersSavedEpisodesRequest.json
@@ -1,0 +1,188 @@
+{
+  "href": "https://api.spotify.com/v1/me/episodes?offset=0&limit=20&market=SE",
+  "items": [
+    {
+      "added_at": "2023-09-26T00:10:20Z",
+      "episode": {
+        "audio_preview_url": "https://podz-content.spotifycdn.com/audio/clips/6MpLrr6CPm6nmORqQlEmDb/clip_959300_1025599.mp3",
+        "description": "Trae Tha Truth is a rapper, record producer, and philanthropist. His new album \"Stuck In Motion\" will be available October 20. http://onerpm.link/stuckinmotion",
+        "duration_ms": 8080446,
+        "explicit": true,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/episode/7H0fhjEd7ImnED3Iab4RI8"
+        },
+        "href": "https://api.spotify.com/v1/episodes/7H0fhjEd7ImnED3Iab4RI8",
+        "html_description": "<p>Trae Tha Truth is a rapper, record producer, and philanthropist. His new album &#34;Stuck In Motion&#34; will be available October 20.</p><br/><p>http://onerpm.link/stuckinmotion</p>",
+        "id": "7H0fhjEd7ImnED3Iab4RI8",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab6765630000ba8a8f9df3cba9b17be2643b46e0",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67656300005f1f8f9df3cba9b17be2643b46e0",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab6765630000f68d8f9df3cba9b17be2643b46e0",
+            "width": 64
+          }
+        ],
+        "is_externally_hosted": false,
+        "is_playable": true,
+        "language": "en-US",
+        "languages": [
+          "en-US"
+        ],
+        "name": "#2038 - Trae Tha Truth",
+        "release_date": "2023-09-21",
+        "release_date_precision": "day",
+        "resume_point": {
+          "fully_played": false,
+          "resume_position_ms": 0
+        },
+        "show": {
+          "available_markets": [
+            "AD",
+            "AE"
+          ],
+          "copyrights": [],
+          "description": "The official podcast of comedian Joe Rogan. Follow The Joe Rogan Clips show page for some of the best moments from the episodes.",
+          "explicit": true,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/show/4rOoJ6Egrf8K2IrywzwOMk"
+          },
+          "href": "https://api.spotify.com/v1/shows/4rOoJ6Egrf8K2IrywzwOMk",
+          "html_description": "The official podcast of comedian Joe Rogan. Follow The Joe Rogan Clips show page for some of the best moments from the episodes.",
+          "id": "4rOoJ6Egrf8K2IrywzwOMk",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/9af79fd06e34dea3cd27c4e1cd6ec7343ce20af4",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/d3ae59a048dff7e95109aec18803f22bebe82d2f",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/97d6fdf3e55a3a1c10662d132232ccbd53740bc3",
+              "width": 64
+            }
+          ],
+          "is_externally_hosted": false,
+          "languages": [
+            "en-US"
+          ],
+          "media_type": "mixed",
+          "name": "The Joe Rogan Experience",
+          "publisher": "Joe Rogan",
+          "total_episodes": 2191,
+          "type": "show",
+          "uri": "spotify:show:4rOoJ6Egrf8K2IrywzwOMk"
+        },
+        "type": "episode",
+        "uri": "spotify:episode:7H0fhjEd7ImnED3Iab4RI8"
+      }
+    },
+    {
+      "added_at": "2023-09-26T00:10:30Z",
+      "episode": {
+        "audio_preview_url": "https://podz-content.spotifycdn.com/audio/clips/4guzjD0NP63f4v18tpCrm9/clip_1022600_1070900.mp3",
+        "description": "Francis Ngannou is a professional mixed martial artist and boxer currently signed to the Professional Fighters League. Ngannou is scheduled to fight boxer Tyson Fury on October 28. https://francisngannoufoundation.com",
+        "duration_ms": 7133566,
+        "explicit": true,
+        "external_urls": {
+          "spotify": "https://open.spotify.com/episode/7rlqqMHZLSsZewJFhlelXd"
+        },
+        "href": "https://api.spotify.com/v1/episodes/7rlqqMHZLSsZewJFhlelXd",
+        "html_description": "<p>Francis Ngannou is a professional mixed martial artist and boxer currently signed to the Professional Fighters League. Ngannou is scheduled to fight boxer Tyson Fury on October 28.</p><br/><p><a href=\"https://francisngannoufoundation.com/\" rel=\"nofollow\">https://francisngannoufoundation.com</a></p>",
+        "id": "7rlqqMHZLSsZewJFhlelXd",
+        "images": [
+          {
+            "height": 640,
+            "url": "https://i.scdn.co/image/ab6765630000ba8afc701a0dfe7e0334853e7ee2",
+            "width": 640
+          },
+          {
+            "height": 300,
+            "url": "https://i.scdn.co/image/ab67656300005f1ffc701a0dfe7e0334853e7ee2",
+            "width": 300
+          },
+          {
+            "height": 64,
+            "url": "https://i.scdn.co/image/ab6765630000f68dfc701a0dfe7e0334853e7ee2",
+            "width": 64
+          }
+        ],
+        "is_externally_hosted": false,
+        "is_playable": true,
+        "language": "en-US",
+        "languages": [
+          "en-US"
+        ],
+        "name": "JRE MMA Show #146 with Francis Ngannou",
+        "release_date": "2023-09-22",
+        "release_date_precision": "day",
+        "resume_point": {
+          "fully_played": false,
+          "resume_position_ms": 0
+        },
+        "show": {
+          "available_markets": [
+            "AD",
+            "AE"
+          ],
+          "copyrights": [],
+          "description": "The official podcast of comedian Joe Rogan. Follow The Joe Rogan Clips show page for some of the best moments from the episodes.",
+          "explicit": true,
+          "external_urls": {
+            "spotify": "https://open.spotify.com/show/4rOoJ6Egrf8K2IrywzwOMk"
+          },
+          "href": "https://api.spotify.com/v1/shows/4rOoJ6Egrf8K2IrywzwOMk",
+          "html_description": "The official podcast of comedian Joe Rogan. Follow The Joe Rogan Clips show page for some of the best moments from the episodes.",
+          "id": "4rOoJ6Egrf8K2IrywzwOMk",
+          "images": [
+            {
+              "height": 640,
+              "url": "https://i.scdn.co/image/9af79fd06e34dea3cd27c4e1cd6ec7343ce20af4",
+              "width": 640
+            },
+            {
+              "height": 300,
+              "url": "https://i.scdn.co/image/d3ae59a048dff7e95109aec18803f22bebe82d2f",
+              "width": 300
+            },
+            {
+              "height": 64,
+              "url": "https://i.scdn.co/image/97d6fdf3e55a3a1c10662d132232ccbd53740bc3",
+              "width": 64
+            }
+          ],
+          "is_externally_hosted": false,
+          "languages": [
+            "en-US"
+          ],
+          "media_type": "mixed",
+          "name": "The Joe Rogan Experience",
+          "publisher": "Joe Rogan",
+          "total_episodes": 2191,
+          "type": "show",
+          "uri": "spotify:show:4rOoJ6Egrf8K2IrywzwOMk"
+        },
+        "type": "episode",
+        "uri": "spotify:episode:7rlqqMHZLSsZewJFhlelXd"
+      }
+    }
+  ],
+  "limit": 20,
+  "next": null,
+  "offset": 0,
+  "previous": null,
+  "total": 2
+}

--- a/src/test/java/se/michaelthelin/spotify/ITest.java
+++ b/src/test/java/se/michaelthelin/spotify/ITest.java
@@ -74,6 +74,7 @@ public interface ITest<T> {
   String SEED_TRACKS = "01iyCAUm8EvOFqVWYJ3dVX";
   boolean SHOW_DIALOG = true;
   JsonArray SHOWS = JsonParser.parseString("[\"5AvwZVawapvyhJUIx71pdJ\", \"5AvwZVawapvyhJUIx71pdJ\"]").getAsJsonArray();
+  JsonArray EPISODES = JsonParser.parseString("[\"4GI3dxEafwap1sFiTGPKd1\", \"4GI3dxEafwap1sFiTGPKd1\"]").getAsJsonArray();
   String SNAPSHOT_ID = "JbtmHBDBAYu3/bt8BOXKjzKx3i0b6LCa/wVjyl6qQ2Yf6nFXkbmzuEa+ZI/U1yF+";
   String STATE = "track";
   boolean STATE_BOOLEAN = false;

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/CheckUsersSavedEpisodesRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/CheckUsersSavedEpisodesRequestTest.java
@@ -1,0 +1,49 @@
+package se.michaelthelin.spotify.requests.data.library;
+
+import org.apache.hc.core5.http.ParseException;
+import org.junit.jupiter.api.Test;
+import se.michaelthelin.spotify.ITest;
+import se.michaelthelin.spotify.TestUtil;
+import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
+import se.michaelthelin.spotify.requests.data.AbstractDataTest;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CheckUsersSavedEpisodesRequestTest extends AbstractDataTest<Boolean[]> {
+  private final CheckUsersSavedEpisodesRequest defaultRequest = ITest.SPOTIFY_API
+    .checkUsersSavedEpisodes(ITest.ID_EPISODE, ITest.ID_EPISODE)
+    .setHttpManager(
+      TestUtil.MockedHttpManager.returningJson(
+        "requests/data/library/CheckUsersSavedEpisodesRequest.json"))
+    .build();
+
+  public CheckUsersSavedEpisodesRequestTest() throws Exception {
+  }
+
+  @Test
+  public void shouldComplyWithReference() {
+    assertHasAuthorizationHeader(defaultRequest);
+    assertEquals(
+      "https://api.spotify.com:443/v1/me/episodes/contains?ids=4GI3dxEafwap1sFiTGPKd1%2C4GI3dxEafwap1sFiTGPKd1",
+      defaultRequest.getUri().toString());
+  }
+
+  @Test
+  public void shouldReturnDefault_sync() throws IOException, SpotifyWebApiException, ParseException {
+    shouldReturnDefault(defaultRequest.execute());
+  }
+
+  @Test
+  public void shouldReturnDefault_async() throws ExecutionException, InterruptedException {
+    shouldReturnDefault(defaultRequest.executeAsync().get());
+  }
+
+  public void shouldReturnDefault(final Boolean[] booleans) {
+    assertEquals(
+      2,
+      booleans.length);
+  }
+}

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/GetUsersSavedEpisodesRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/GetUsersSavedEpisodesRequestTest.java
@@ -6,7 +6,7 @@ import se.michaelthelin.spotify.ITest;
 import se.michaelthelin.spotify.TestUtil;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.specification.Paging;
-import se.michaelthelin.spotify.model_objects.specification.SavedEpisode;
+import se.michaelthelin.spotify.model_objects.miscellaneous.SavedEpisode;
 import se.michaelthelin.spotify.requests.data.AbstractDataTest;
 
 import java.io.IOException;

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/GetUsersSavedEpisodesRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/GetUsersSavedEpisodesRequestTest.java
@@ -1,0 +1,80 @@
+package se.michaelthelin.spotify.requests.data.library;
+
+import org.apache.hc.core5.http.ParseException;
+import org.junit.jupiter.api.Test;
+import se.michaelthelin.spotify.ITest;
+import se.michaelthelin.spotify.TestUtil;
+import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
+import se.michaelthelin.spotify.model_objects.specification.Paging;
+import se.michaelthelin.spotify.model_objects.specification.SavedEpisode;
+import se.michaelthelin.spotify.requests.data.AbstractDataTest;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Date;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class GetUsersSavedEpisodesRequestTest extends AbstractDataTest<Paging<SavedEpisode>> {
+  private final GetUsersSavedEpisodesRequest defaultRequest = ITest.SPOTIFY_API.getUsersSavedEpisodes()
+    .setHttpManager(
+      TestUtil.MockedHttpManager.returningJson(
+        "requests/data/library/GetUsersSavedEpisodesRequest.json"))
+    .limit(ITest.LIMIT)
+    .offset(ITest.OFFSET)
+    .market(ITest.MARKET)
+    .build();
+
+  public GetUsersSavedEpisodesRequestTest() throws Exception {
+  }
+
+  @Test
+  public void shouldComplyWithReference() {
+    assertHasAuthorizationHeader(defaultRequest);
+    assertEquals(
+      "https://api.spotify.com:443/v1/me/episodes?limit=10&offset=0&market=SE",
+      defaultRequest.getUri().toString());
+  }
+
+  @Test
+  public void shouldReturnDefault_sync() throws IOException, SpotifyWebApiException, ParseException {
+    shouldReturnDefault(defaultRequest.execute());
+  }
+
+  @Test
+  public void shouldReturnDefault_async() throws ExecutionException, InterruptedException {
+    shouldReturnDefault(defaultRequest.executeAsync().get());
+  }
+
+  public void shouldReturnDefault(final Paging<SavedEpisode> savedEpisodesPaging) {
+    assertEquals(
+      "https://api.spotify.com/v1/me/episodes?offset=0&limit=20&market=SE",
+      savedEpisodesPaging.getHref());
+    assertEquals(
+      2,
+      savedEpisodesPaging.getItems().length);
+    assertEquals(
+      20,
+      (int) savedEpisodesPaging.getLimit());
+    assertNull(
+      savedEpisodesPaging.getNext());
+    assertEquals(
+      0,
+      (int) savedEpisodesPaging.getOffset());
+    assertNull(
+      savedEpisodesPaging.getPrevious());
+    assertEquals(
+      2,
+      (int) savedEpisodesPaging.getTotal());
+
+    SavedEpisode[] savedEpisodes = savedEpisodesPaging.getItems();
+    assertEquals(
+      Date.from(Instant.parse("2023-09-26T00:10:20Z")),
+      savedEpisodes[0].getAddedAt());
+    assertEquals(
+      "#2038 - Trae Tha Truth",
+      savedEpisodes[0].getEpisode().getName());
+  }
+}

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/RemoveUsersSavedEpisodesRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/RemoveUsersSavedEpisodesRequestTest.java
@@ -1,0 +1,63 @@
+package se.michaelthelin.spotify.requests.data.library;
+
+import org.apache.hc.core5.http.ParseException;
+import org.junit.jupiter.api.Test;
+import se.michaelthelin.spotify.ITest;
+import se.michaelthelin.spotify.TestUtil;
+import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
+import se.michaelthelin.spotify.requests.data.AbstractDataTest;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
+import static se.michaelthelin.spotify.Assertions.assertHasHeader;
+
+public class RemoveUsersSavedEpisodesRequestTest extends AbstractDataTest<String> {
+  private final RemoveUsersSavedEpisodesRequest defaultRequest = ITest.SPOTIFY_API
+    .removeUsersSavedEpisodes(ITest.ID_EPISODE, ITest.ID_EPISODE)
+    .setHttpManager(
+      TestUtil.MockedHttpManager.returningJson(null))
+    .build();
+  private final RemoveUsersSavedEpisodesRequest bodyRequest = ITest.SPOTIFY_API
+    .removeUsersSavedEpisodes(ITest.EPISODES)
+    .setHttpManager(
+      TestUtil.MockedHttpManager.returningJson(null))
+    .build();
+
+  public RemoveUsersSavedEpisodesRequestTest() throws Exception {
+  }
+
+  @Test
+  public void shouldComplyWithReference() {
+    assertHasAuthorizationHeader(defaultRequest);
+    assertEquals(
+      "https://api.spotify.com:443/v1/me/episodes?ids=4GI3dxEafwap1sFiTGPKd1%2C4GI3dxEafwap1sFiTGPKd1",
+      defaultRequest.getUri().toString());
+
+    assertHasAuthorizationHeader(bodyRequest);
+    assertHasHeader(defaultRequest, "Content-Type", "application/json");
+    assertHasBodyParameter(bodyRequest,
+      "ids",
+      ITest.EPISODES);
+    assertEquals("https://api.spotify.com:443/v1/me/episodes",
+      bodyRequest.getUri().toString());
+  }
+
+  @Test
+  public void shouldReturnDefault_sync() throws IOException, SpotifyWebApiException, ParseException {
+    shouldReturnDefault(defaultRequest.execute());
+  }
+
+  @Test
+  public void shouldReturnDefault_async() throws ExecutionException, InterruptedException {
+    shouldReturnDefault(defaultRequest.executeAsync().get());
+  }
+
+  public void shouldReturnDefault(final String string) {
+    assertNull(
+      string);
+  }
+}

--- a/src/test/java/se/michaelthelin/spotify/requests/data/library/SaveEpisodesForCurrentUserRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/library/SaveEpisodesForCurrentUserRequestTest.java
@@ -1,0 +1,63 @@
+package se.michaelthelin.spotify.requests.data.library;
+
+import org.apache.hc.core5.http.ParseException;
+import org.junit.jupiter.api.Test;
+import se.michaelthelin.spotify.ITest;
+import se.michaelthelin.spotify.TestUtil;
+import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
+import se.michaelthelin.spotify.requests.data.AbstractDataTest;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static se.michaelthelin.spotify.Assertions.assertHasBodyParameter;
+import static se.michaelthelin.spotify.Assertions.assertHasHeader;
+
+public class SaveEpisodesForCurrentUserRequestTest extends AbstractDataTest<String> {
+  private final SaveEpisodesForCurrentUserRequest defaultRequest = ITest.SPOTIFY_API
+    .saveEpisodesForCurrentUser(ITest.ID_EPISODE, ITest.ID_EPISODE)
+    .setHttpManager(
+      TestUtil.MockedHttpManager.returningJson(null))
+    .build();
+  private final SaveEpisodesForCurrentUserRequest bodyRequest = ITest.SPOTIFY_API
+    .saveEpisodesForCurrentUser(ITest.EPISODES)
+    .setHttpManager(
+      TestUtil.MockedHttpManager.returningJson(null))
+    .build();
+
+  public SaveEpisodesForCurrentUserRequestTest() throws Exception {
+  }
+
+  @Test
+  public void shouldComplyWithReference() {
+    assertHasAuthorizationHeader(defaultRequest);
+    assertEquals(
+      "https://api.spotify.com:443/v1/me/episodes?ids=4GI3dxEafwap1sFiTGPKd1%2C4GI3dxEafwap1sFiTGPKd1",
+      defaultRequest.getUri().toString());
+
+    assertHasAuthorizationHeader(bodyRequest);
+    assertHasHeader(defaultRequest, "Content-Type", "application/json");
+    assertHasBodyParameter(bodyRequest,
+      "ids",
+      ITest.EPISODES);
+    assertEquals("https://api.spotify.com:443/v1/me/episodes",
+      bodyRequest.getUri().toString());
+  }
+
+  @Test
+  public void shouldReturnDefault_sync() throws IOException, SpotifyWebApiException, ParseException {
+    shouldReturnDefault(defaultRequest.execute());
+  }
+
+  @Test
+  public void shouldReturnDefault_async() throws ExecutionException, InterruptedException {
+    shouldReturnDefault(defaultRequest.executeAsync().get());
+  }
+
+  public void shouldReturnDefault(final String string) {
+    assertNull(
+      string);
+  }
+}


### PR DESCRIPTION
Added 4 episode endpoints which were added to Spotify API a couple years ago.

- [Get User's Saved Episodes](https://developer.spotify.com/documentation/web-api/reference/get-users-saved-episodes)
- [Save Episodes for Current User](https://developer.spotify.com/documentation/web-api/reference/save-episodes-user)
- [Remove User's Saved Episodes](https://developer.spotify.com/documentation/web-api/reference/remove-episodes-user)
- [Check User's Saved Episodes](https://developer.spotify.com/documentation/web-api/reference/check-users-saved-episodes)

Note, these endpoints are actually still in beta, from documentation: `This API endpoint is in beta and could change without warning.`.