### PR TITLE
fix: add temporary workaround for local files' `duration_ms` anomaly

### DIFF
--- a/src/main/java/se/michaelthelin/spotify/model_objects/specification/Track.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/specification/Track.java
@@ -632,6 +632,7 @@ public class Track extends AbstractModelObject implements IArtistTrackModelObjec
      * @deprecated This is a TEMPORARY workaround to handle an edge-case involving local files,
      * which for some reason have their duration_ms field contain an additional field called totalMilliseconds.
      * Once Spotify fixes their API, this workaround should be removed!
+     * @see <a href="https://community.spotify.com/t5/Spotify-for-Developers/duration-ms-includes-nonsense-JSON/m-p/5753768">Bug report on Spotify forums</a>
      */
     @Deprecated
     private static int getDurationMsFixed(JsonObject jsonObject) {

--- a/src/main/java/se/michaelthelin/spotify/model_objects/specification/Track.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/specification/Track.java
@@ -562,7 +562,7 @@ public class Track extends AbstractModelObject implements IArtistTrackModelObjec
             : null)
         .setDurationMs(
           hasAndNotNull(jsonObject, "duration_ms")
-            ? getDurationMsFixed(jsonObject)
+            ? getDurationMsFixed(jsonObject) // TODO: use `jsonObject.get("duration_ms").getAsInt()` when Spotify has fixed their API / API description, see method documentation below
             : null)
         .setExplicit(
           hasAndNotNull(jsonObject, "explicit")
@@ -629,10 +629,10 @@ public class Track extends AbstractModelObject implements IArtistTrackModelObjec
     }
 
     /**
-     * @deprecated This is a TEMPORARY workaround to handle an edge-case involving local files,
-     * which for some reason have their duration_ms field contain an additional field called totalMilliseconds.
-     * Once Spotify fixes their API, this workaround should be removed!
      * @see <a href="https://community.spotify.com/t5/Spotify-for-Developers/duration-ms-includes-nonsense-JSON/m-p/5753768">Bug report on Spotify forums</a>
+     * @deprecated This is a temporary workaround to handle an edge-case involving local files,
+     * which for some reason have their duration_ms field contain an additional field called totalMilliseconds.
+     * Once Spotify fixes their API, this workaround should be removed.
      */
     @Deprecated
     private static int getDurationMsFixed(JsonObject jsonObject) {

--- a/src/main/java/se/michaelthelin/spotify/model_objects/specification/Track.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/specification/Track.java
@@ -2,6 +2,7 @@ package se.michaelthelin.spotify.model_objects.specification;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.gson.Gson;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.neovisionaries.i18n.CountryCode;
 import se.michaelthelin.spotify.enums.ModelObjectType;
@@ -273,11 +274,11 @@ public class Track extends AbstractModelObject implements IArtistTrackModelObjec
   @Override
   public String toString() {
     return "Track(name=" + name + ", artists=" + Arrays.toString(artists) + ", album=" + album + ", availableMarkets="
-        + Arrays.toString(availableMarkets) + ", discNumber=" + discNumber + ", durationMs=" + durationMs
-        + ", explicit=" + explicit + ", externalIds=" + externalIds + ", externalUrls=" + externalUrls + ", href="
-        + href + ", id=" + id + ", isPlayable=" + isPlayable + ", linkedFrom=" + linkedFrom + ", restrictions="
-        + restrictions + ", popularity=" + popularity + ", previewUrl=" + previewUrl + ", trackNumber=" + trackNumber
-        + ", type=" + type + ", uri=" + uri + ")";
+      + Arrays.toString(availableMarkets) + ", discNumber=" + discNumber + ", durationMs=" + durationMs
+      + ", explicit=" + explicit + ", externalIds=" + externalIds + ", externalUrls=" + externalUrls + ", href="
+      + href + ", id=" + id + ", isPlayable=" + isPlayable + ", linkedFrom=" + linkedFrom + ", restrictions="
+      + restrictions + ", popularity=" + popularity + ", previewUrl=" + previewUrl + ", trackNumber=" + trackNumber
+      + ", type=" + type + ", uri=" + uri + ")";
   }
 
   @Override
@@ -561,7 +562,7 @@ public class Track extends AbstractModelObject implements IArtistTrackModelObjec
             : null)
         .setDurationMs(
           hasAndNotNull(jsonObject, "duration_ms")
-            ? jsonObject.get("duration_ms").getAsInt()
+            ? getDurationMsFixed(jsonObject)
             : null)
         .setExplicit(
           hasAndNotNull(jsonObject, "explicit")
@@ -625,6 +626,21 @@ public class Track extends AbstractModelObject implements IArtistTrackModelObjec
             ? jsonObject.get("uri").getAsString()
             : null)
         .build();
+    }
+
+    /**
+     * @deprecated This is a TEMPORARY workaround to handle an edge-case involving local files,
+     * which for some reason have their duration_ms field contain an additional field called totalMilliseconds.
+     * Once Spotify fixes their API, this workaround should be removed!
+     */
+    @Deprecated
+    private static int getDurationMsFixed(JsonObject jsonObject) {
+      JsonElement durationMs = jsonObject.get("duration_ms");
+      if (durationMs.isJsonPrimitive()) {
+        return durationMs.getAsInt();
+      } else {
+        return durationMs.getAsJsonObject().get("totalMilliseconds").getAsInt();
+      }
     }
   }
 

--- a/src/test/fixtures/requests/data/tracks/GetTrackRequestLocal.json
+++ b/src/test/fixtures/requests/data/tracks/GetTrackRequestLocal.json
@@ -1,0 +1,191 @@
+{
+  "album": {
+    "album_type": "album",
+    "artists": [
+      {
+        "external_urls": {
+          "spotify": "https://open.spotify.com/artist/0C0XlULifJtAgn6ZNCW2eu"
+        },
+        "href": "https://api.spotify.com/v1/artists/0C0XlULifJtAgn6ZNCW2eu",
+        "id": "0C0XlULifJtAgn6ZNCW2eu",
+        "name": "The Killers",
+        "type": "artist",
+        "uri": "spotify:artist:0C0XlULifJtAgn6ZNCW2eu"
+      }
+    ],
+    "available_markets": [
+      "AD",
+      "AR",
+      "AT",
+      "AU",
+      "BE",
+      "BG",
+      "BO",
+      "BR",
+      "CH",
+      "CL",
+      "CO",
+      "CR",
+      "CY",
+      "CZ",
+      "DE",
+      "DK",
+      "DO",
+      "EC",
+      "EE",
+      "ES",
+      "FI",
+      "FR",
+      "GB",
+      "GR",
+      "GT",
+      "HK",
+      "HN",
+      "HU",
+      "ID",
+      "IE",
+      "IS",
+      "IT",
+      "JP",
+      "LI",
+      "LT",
+      "LU",
+      "LV",
+      "MC",
+      "MT",
+      "MY",
+      "NI",
+      "NL",
+      "NO",
+      "NZ",
+      "PA",
+      "PE",
+      "PH",
+      "PL",
+      "PT",
+      "PY",
+      "SE",
+      "SG",
+      "SK",
+      "SV",
+      "TR",
+      "TW",
+      "UY"
+    ],
+    "external_urls": {
+      "spotify": "https://open.spotify.com/album/4OHNH3sDzIxnmUADXzv2kT"
+    },
+    "href": "https://api.spotify.com/v1/albums/4OHNH3sDzIxnmUADXzv2kT",
+    "id": "4OHNH3sDzIxnmUADXzv2kT",
+    "images": [
+      {
+        "height": 640,
+        "url": "https://i.scdn.co/image/ac68a9e4a867ec3ce8249cd90a2d7c73755fb487",
+        "width": 629
+      },
+      {
+        "height": 300,
+        "url": "https://i.scdn.co/image/d0186ad64df7d6fc5f65c20c7d16f4279ffeb815",
+        "width": 295
+      },
+      {
+        "height": 64,
+        "url": "https://i.scdn.co/image/7c3ec33d478f5f517eeb5339c2f75f150e4d601e",
+        "width": 63
+      }
+    ],
+    "name": "Hot Fuss (Deluxe Version)",
+    "type": "album",
+    "uri": "spotify:album:4OHNH3sDzIxnmUADXzv2kT"
+  },
+  "artists": [
+    {
+      "external_urls": {
+        "spotify": "https://open.spotify.com/artist/0C0XlULifJtAgn6ZNCW2eu"
+      },
+      "href": "https://api.spotify.com/v1/artists/0C0XlULifJtAgn6ZNCW2eu",
+      "id": "0C0XlULifJtAgn6ZNCW2eu",
+      "name": "The Killers",
+      "type": "artist",
+      "uri": "spotify:artist:0C0XlULifJtAgn6ZNCW2eu"
+    }
+  ],
+  "available_markets": [
+    "AD",
+    "AR",
+    "AT",
+    "AU",
+    "BE",
+    "BG",
+    "BO",
+    "BR",
+    "CH",
+    "CL",
+    "CO",
+    "CR",
+    "CY",
+    "CZ",
+    "DE",
+    "DK",
+    "DO",
+    "EC",
+    "EE",
+    "ES",
+    "FI",
+    "FR",
+    "GB",
+    "GR",
+    "GT",
+    "HK",
+    "HN",
+    "HU",
+    "ID",
+    "IE",
+    "IS",
+    "IT",
+    "JP",
+    "LI",
+    "LT",
+    "LU",
+    "LV",
+    "MC",
+    "MT",
+    "MY",
+    "NI",
+    "NL",
+    "NO",
+    "NZ",
+    "PA",
+    "PE",
+    "PH",
+    "PL",
+    "PT",
+    "PY",
+    "SE",
+    "SG",
+    "SK",
+    "SV",
+    "TR",
+    "TW",
+    "UY"
+  ],
+  "disc_number": 1,
+  "duration_ms": {
+    "totalMilliseconds": 222200
+  },
+  "explicit": false,
+  "external_ids": {
+    "isrc": "GBFFP0300052"
+  },
+  "external_urls": {
+    "spotify": "https://open.spotify.com/track/3n3Ppam7vgaVa1iaRUc9Lp"
+  },
+  "href": "https://api.spotify.com/v1/tracks/3n3Ppam7vgaVa1iaRUc9Lp",
+  "id": "3n3Ppam7vgaVa1iaRUc9Lp",
+  "name": "Mr. Brightside",
+  "popularity": 73,
+  "preview_url": "https://p.scdn.co/mp3-preview/4839b070015ab7d6de9fec1756e1f3096d908fba",
+  "track_number": 2,
+  "type": "track",
+  "uri": "spotify:track:3n3Ppam7vgaVa1iaRUc9Lp"
+}

--- a/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetTrackRequestLocalTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/tracks/GetTrackRequestLocalTest.java
@@ -1,0 +1,51 @@
+package se.michaelthelin.spotify.requests.data.tracks;
+
+import org.apache.hc.core5.http.ParseException;
+import org.junit.jupiter.api.Test;
+import se.michaelthelin.spotify.ITest;
+import se.michaelthelin.spotify.TestUtil;
+import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
+import se.michaelthelin.spotify.model_objects.specification.Track;
+import se.michaelthelin.spotify.requests.data.AbstractDataTest;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class GetTrackRequestLocalTest extends AbstractDataTest<Track> {
+  private final GetTrackRequest defaultRequest = ITest.SPOTIFY_API
+    .getTrack(ITest.ID_TRACK)
+    .setHttpManager(
+      TestUtil.MockedHttpManager.returningJson(
+        "requests/data/tracks/GetTrackRequestLocal.json"))
+    .market(ITest.MARKET)
+    .build();
+
+  public GetTrackRequestLocalTest() throws Exception {
+  }
+
+  @Test
+  public void shouldComplyWithReference() {
+    assertHasAuthorizationHeader(defaultRequest);
+    assertEquals(
+      "https://api.spotify.com:443/v1/tracks/01iyCAUm8EvOFqVWYJ3dVX?market=SE",
+      defaultRequest.getUri().toString());
+  }
+
+  @Test
+  public void shouldReturnDefault_sync() throws IOException, SpotifyWebApiException, ParseException {
+    shouldReturnDefault(defaultRequest.execute());
+  }
+
+  @Test
+  public void shouldReturnDefault_async() throws ExecutionException, InterruptedException {
+    shouldReturnDefault(defaultRequest.executeAsync().get());
+  }
+
+  public void shouldReturnDefault(final Track track) {
+    assertEquals(
+      222200,
+      (int) track.getDurationMs());
+  }
+}


### PR DESCRIPTION
As discussed in https://github.com/spotify-web-api-java/spotify-web-api-java/issues/381