### PR TITLE
Deprecate usage of owner_id param in CheckUsersFollowPlaylist requests to match the updated endpoint

### DIFF
--- a/examples/data/follow/CheckUsersFollowPlaylistExample.java
+++ b/examples/data/follow/CheckUsersFollowPlaylistExample.java
@@ -12,7 +12,6 @@ import java.util.concurrent.CompletionException;
 
 public class CheckUsersFollowPlaylistExample {
   private static final String accessToken = "taHZ2SdB-bPA3FsK3D7ZN5npZS47cMy-IEySVEGttOhXmqaVAIo0ESvTCLjLBifhHOHOIuhFUKPW1WMDP7w6dj3MAZdWT8CLI2MkZaXbYLTeoDvXesf2eeiLYPBGdx8tIwQJKgV8XdnzH_DONk";
-  private static final String ownerId = "abbaspotify";
   private static final String playlistId = "3AGOiaoRXMSjswCLtuNqv5";
   private static final String[] ids = new String[]{"abbaspotify"};
 
@@ -20,7 +19,7 @@ public class CheckUsersFollowPlaylistExample {
     .setAccessToken(accessToken)
     .build();
   private static final CheckUsersFollowPlaylistRequest checkUsersFollowPlaylistRequest = spotifyApi
-    .checkUsersFollowPlaylist(ownerId, playlistId, ids)
+    .checkUsersFollowPlaylist(playlistId, ids)
     .build();
 
   public static void checkUsersFollowPlaylist_Sync() {

--- a/src/main/java/se/michaelthelin/spotify/SpotifyApi.java
+++ b/src/main/java/se/michaelthelin/spotify/SpotifyApi.java
@@ -776,12 +776,32 @@ public class SpotifyApi {
    *                    follow the playlist. Maximum: 5 IDs.
    * @return A {@link CheckUsersFollowPlaylistRequest.Builder}.
    * @see <a href="https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids">Spotify: URLs &amp; IDs</a>
+   *
+   * @deprecated since the endpoint no longer needs the owner_id param. Use {@link #checkUsersFollowPlaylist(String, String[])} instead.
    */
+  @Deprecated(since = "8.3.7")
   public CheckUsersFollowPlaylistRequest.Builder checkUsersFollowPlaylist(
     String owner_id, String playlist_id, String[] ids) {
     return new CheckUsersFollowPlaylistRequest.Builder(accessToken)
       .setDefaults(httpManager, scheme, host, port)
       .owner_id(owner_id)
+      .playlist_id(playlist_id)
+      .ids(concat(ids, ','));
+  }
+
+  /**
+   * Check to see if one or more Spotify users are following a specified playlist.
+   *
+   * @param playlist_id The Spotify ID of the playlist.
+   * @param ids         A list of Spotify User IDs; the IDs of the users that you want to check to see if they
+   *                    follow the playlist. Maximum: 5 IDs.
+   * @return A {@link CheckUsersFollowPlaylistRequest.Builder}.
+   * @see <a href="https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids">Spotify: URLs &amp; IDs</a>
+   */
+  public CheckUsersFollowPlaylistRequest.Builder checkUsersFollowPlaylist(
+    String playlist_id, String[] ids) {
+    return new CheckUsersFollowPlaylistRequest.Builder(accessToken)
+      .setDefaults(httpManager, scheme, host, port)
       .playlist_id(playlist_id)
       .ids(concat(ids, ','));
   }

--- a/src/main/java/se/michaelthelin/spotify/requests/data/follow/CheckUsersFollowPlaylistRequest.java
+++ b/src/main/java/se/michaelthelin/spotify/requests/data/follow/CheckUsersFollowPlaylistRequest.java
@@ -65,7 +65,10 @@ public class CheckUsersFollowPlaylistRequest extends AbstractDataRequest<Boolean
      * @param owner_id The Spotify user ID of the person who owns the playlist.
      * @return A {@link CheckUsersFollowPlaylistRequest.Builder}.
      * @see <a href="https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids">Spotify: URIs &amp; IDs</a>
+     *
+     * @deprecated since the endpoint no longer needs it.
      */
+    @Deprecated(since = "8.3.7")
     public Builder owner_id(final String owner_id) {
       assert (owner_id != null);
       assert (!owner_id.isEmpty());
@@ -106,7 +109,7 @@ public class CheckUsersFollowPlaylistRequest extends AbstractDataRequest<Boolean
      */
     @Override
     public CheckUsersFollowPlaylistRequest build() {
-      setPath("/v1/users/{owner_id}/playlists/{playlist_id}/followers/contains");
+      setPath("/v1/playlists/{playlist_id}/followers/contains");
       return new CheckUsersFollowPlaylistRequest(this);
     }
 

--- a/src/test/java/se/michaelthelin/spotify/requests/data/follow/CheckUsersFollowPlaylistRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/follow/CheckUsersFollowPlaylistRequestTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CheckUsersFollowPlaylistRequestTest extends AbstractDataTest<Boolean[]> {
   private final CheckUsersFollowPlaylistRequest defaultRequest = SPOTIFY_API
-    .checkUsersFollowPlaylist(ID_USER, ID_PLAYLIST, new String[]{ID_USER, ID_USER})
+    .checkUsersFollowPlaylist(ID_PLAYLIST, new String[]{ID_USER, ID_USER})
     .setHttpManager(
       TestUtil.MockedHttpManager.returningJson(
         "requests/data/follow/CheckUsersFollowPlaylistRequest.json"))
@@ -26,7 +26,7 @@ public class CheckUsersFollowPlaylistRequestTest extends AbstractDataTest<Boolea
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
     assertEquals(
-      "https://api.spotify.com:443/v1/users/abbaspotify/playlists/3AGOiaoRXMSjswCLtuNqv5/followers/contains?ids=abbaspotify%2Cabbaspotify",
+      "https://api.spotify.com:443/v1/playlists/3AGOiaoRXMSjswCLtuNqv5/followers/contains?ids=abbaspotify%2Cabbaspotify",
       defaultRequest.getUri().toString());
   }
 


### PR DESCRIPTION
As discussed in #395 , this is a pull request linked to #396 that removes the usage of the `owner_id` param in CheckUsersFollowPlaylist requests since it is no longer in documentation and might break in the futur. The methods using `owner_id` param are now deprecated, allowing users to update their codes before removal.