### PR TITLE
Fix NPE

### DIFF
--- a/src/main/java/se/michaelthelin/spotify/SpotifyHttpManager.java
+++ b/src/main/java/se/michaelthelin/spotify/SpotifyHttpManager.java
@@ -68,7 +68,7 @@ public class SpotifyHttpManager implements IHttpManager {
 
     BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
 
-    if (proxy != null) {
+    if (proxy != null && proxyCredentials != null) {
       credentialsProvider.setCredentials(
         new AuthScope(null, proxy.getHostName(), proxy.getPort(), null, proxy.getSchemeName()),
         proxyCredentials


### PR DESCRIPTION
Fix NPE if a proxy was set in the SpotifyHttpManager.Builder, but proxyCredentials are not required / not set.