### PR TITLE
expose backward compatible connection mgr

### DIFF
--- a/src/main/java/se/michaelthelin/spotify/SpotifyHttpManager.java
+++ b/src/main/java/se/michaelthelin/spotify/SpotifyHttpManager.java
@@ -410,7 +410,7 @@ public class SpotifyHttpManager implements IHttpManager {
             Timeout.ofMilliseconds(this.connectTimeout) :
             ConnectionConfig.DEFAULT.getConnectTimeout())
           .build());
-        this.connectionManager = basicHttpClientConnectionManager;
+        connectionManager = basicHttpClientConnectionManager;
       }
 
       return connectionManager;

--- a/src/main/java/se/michaelthelin/spotify/SpotifyHttpManager.java
+++ b/src/main/java/se/michaelthelin/spotify/SpotifyHttpManager.java
@@ -406,8 +406,8 @@ public class SpotifyHttpManager implements IHttpManager {
         BasicHttpClientConnectionManager basicHttpClientConnectionManager = new BasicHttpClientConnectionManager();
         basicHttpClientConnectionManager.setConnectionConfig(ConnectionConfig
           .custom()
-          .setConnectTimeout(this.connectTimeout != null ?
-            Timeout.ofMilliseconds(this.connectTimeout) :
+          .setConnectTimeout(connectTimeout != null ?
+            Timeout.ofMilliseconds(connectTimeout) :
             ConnectionConfig.DEFAULT.getConnectTimeout())
           .build());
         connectionManager = basicHttpClientConnectionManager;


### PR DESCRIPTION
* expose http connection mgr with backwards compatibility
* add HttpClientConnectionManager to SpotifyHttpManager.builder
* add SpotifyHttpManager.Builder.getConnectionManager to handle default

Similar to #375, but providing backwards compatibility to be included in a 8.4.2.

The default usage does not change, however adding support for PoolingHttpClientConnectionManager would look like this:
```java
    var spotifyApi = SpotifyApi.builder()
        .setHttpManager(new SpotifyHttpManager.Builder()
            .setConnectionManager(new PoolingHttpClientConnectionManager())
            .build())
        .setClientId("foo")
        .setClientSecret("bar")
        .build();
```