### PR TITLE
feat(http): expose connection manager

### DIFF
--- a/src/main/java/se/michaelthelin/spotify/SpotifyHttpManager.java
+++ b/src/main/java/se/michaelthelin/spotify/SpotifyHttpManager.java
@@ -410,7 +410,7 @@ public class SpotifyHttpManager implements IHttpManager {
             Timeout.ofMilliseconds(this.connectTimeout) :
             ConnectionConfig.DEFAULT.getConnectTimeout())
           .build());
-        this.connectionManager = basicHttpClientConnectionManager;
+        connectionManager = basicHttpClientConnectionManager;
       }
 
       return connectionManager;

--- a/src/main/java/se/michaelthelin/spotify/SpotifyHttpManager.java
+++ b/src/main/java/se/michaelthelin/spotify/SpotifyHttpManager.java
@@ -406,8 +406,8 @@ public class SpotifyHttpManager implements IHttpManager {
         BasicHttpClientConnectionManager basicHttpClientConnectionManager = new BasicHttpClientConnectionManager();
         basicHttpClientConnectionManager.setConnectionConfig(ConnectionConfig
           .custom()
-          .setConnectTimeout(this.connectTimeout != null ?
-            Timeout.ofMilliseconds(this.connectTimeout) :
+          .setConnectTimeout(connectTimeout != null ?
+            Timeout.ofMilliseconds(connectTimeout) :
             ConnectionConfig.DEFAULT.getConnectTimeout())
           .build());
         connectionManager = basicHttpClientConnectionManager;


### PR DESCRIPTION
Builds upon https://github.com/spotify-web-api-java/spotify-web-api-java/pull/407, keeping the setter-only builder architecture.