### PR TITLE
fix(track): remove special-case handling of local `duration_ms`

### DIFF
--- a/src/main/java/se/michaelthelin/spotify/model_objects/specification/Track.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/specification/Track.java
@@ -562,7 +562,7 @@ public class Track extends AbstractModelObject implements IArtistTrackModelObjec
             : null)
         .setDurationMs(
           hasAndNotNull(jsonObject, "duration_ms")
-            ? getDurationMsFixed(jsonObject) // TODO: use `jsonObject.get("duration_ms").getAsInt()` when Spotify has fixed their API / API description, see method documentation below
+            ? jsonObject.get("duration_ms").getAsInt()
             : null)
         .setExplicit(
           hasAndNotNull(jsonObject, "explicit")
@@ -626,22 +626,6 @@ public class Track extends AbstractModelObject implements IArtistTrackModelObjec
             ? jsonObject.get("uri").getAsString()
             : null)
         .build();
-    }
-
-    /**
-     * @see <a href="https://community.spotify.com/t5/Spotify-for-Developers/duration-ms-includes-nonsense-JSON/m-p/5753768">Bug report on Spotify forums</a>
-     * @deprecated This is a temporary workaround to handle an edge-case involving local files,
-     * which for some reason have their duration_ms field contain an additional field called totalMilliseconds.
-     * Once Spotify fixes their API, this workaround should be removed.
-     */
-    @Deprecated
-    private static int getDurationMsFixed(JsonObject jsonObject) {
-      JsonElement durationMs = jsonObject.get("duration_ms");
-      if (durationMs.isJsonPrimitive()) {
-        return durationMs.getAsInt();
-      } else {
-        return durationMs.getAsJsonObject().get("totalMilliseconds").getAsInt();
-      }
     }
   }
 

--- a/src/test/fixtures/requests/data/tracks/GetTrackRequestLocal.json
+++ b/src/test/fixtures/requests/data/tracks/GetTrackRequestLocal.json
@@ -170,9 +170,7 @@
     "UY"
   ],
   "disc_number": 1,
-  "duration_ms": {
-    "totalMilliseconds": 222200
-  },
+  "duration_ms": 222200,
   "explicit": false,
   "external_ids": {
     "isrc": "GBFFP0300052"


### PR DESCRIPTION
* https://community.spotify.com/t5/Spotify-for-Developers/duration-ms-includes-nonsense-JSON/m-p/5753768