### PR TITLE
fix: throw Exception on all 4xx and 5xx status codes

### DIFF
--- a/src/main/java/se/michaelthelin/spotify/SpotifyHttpManager.java
+++ b/src/main/java/se/michaelthelin/spotify/SpotifyHttpManager.java
@@ -1,6 +1,10 @@
 package se.michaelthelin.spotify;
 
-import com.google.gson.*;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
 import org.apache.hc.client5.http.HttpRequestRetryStrategy;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
@@ -20,11 +24,23 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
-import org.apache.hc.core5.http.*;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.ParseException;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.util.Timeout;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
-import se.michaelthelin.spotify.exceptions.detailed.*;
+import se.michaelthelin.spotify.exceptions.detailed.BadGatewayException;
+import se.michaelthelin.spotify.exceptions.detailed.BadRequestException;
+import se.michaelthelin.spotify.exceptions.detailed.ForbiddenException;
+import se.michaelthelin.spotify.exceptions.detailed.InternalServerErrorException;
+import se.michaelthelin.spotify.exceptions.detailed.NotFoundException;
+import se.michaelthelin.spotify.exceptions.detailed.ServiceUnavailableException;
+import se.michaelthelin.spotify.exceptions.detailed.TooManyRequestsException;
+import se.michaelthelin.spotify.exceptions.detailed.UnauthorizedException;
 
 import java.io.IOException;
 import java.net.URI;
@@ -350,6 +366,11 @@ public class SpotifyHttpManager implements IHttpManager {
       case HttpStatus.SC_SERVICE_UNAVAILABLE:
         throw new ServiceUnavailableException(errorMessage);
       default:
+        if (httpResponse.getCode() >= 400 && httpResponse.getCode() < 500) {
+          throw new BadRequestException(errorMessage);
+        } else if (httpResponse.getCode() >= 500) {
+          throw new InternalServerErrorException(errorMessage);
+        }
         return responseBody;
     }
   }

--- a/src/test/java/se/michaelthelin/spotify/SpotifyHttpManagerTest.java
+++ b/src/test/java/se/michaelthelin/spotify/SpotifyHttpManagerTest.java
@@ -1,0 +1,45 @@
+package se.michaelthelin.spotify;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import org.apache.hc.core5.http.Header;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import se.michaelthelin.spotify.SpotifyHttpManager.Builder;
+import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
+
+import java.net.URI;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+
+@WireMockTest(httpPort = 9090)
+class SpotifyHttpManagerTest {
+
+  private final SpotifyHttpManager spotifyHttpManager = new SpotifyHttpManager(new Builder());
+
+  @ParameterizedTest
+  @ValueSource(ints = {405, 409, 410, 414, 422, 431, 499})
+  public void throwsSpotifyWebApiExceptionForAll4xxStatusCodes(int statusCode) {
+
+    stubFor(get("/test/foo/")
+      .willReturn(aResponse()
+        .withStatus(statusCode)));
+
+    Assertions.assertThrows(SpotifyWebApiException.class, () ->
+      spotifyHttpManager.get(URI.create("http://localhost:9090/test/foo/"), new Header[0]));
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {501, 504, 599})
+  public void throwsSpotifyWebApiExceptionForAll5xxStatusCodes(int statusCode) {
+
+    stubFor(get("/test/foo/")
+      .willReturn(aResponse()
+        .withStatus(statusCode)));
+
+    Assertions.assertThrows(SpotifyWebApiException.class, () ->
+      spotifyHttpManager.get(URI.create("http://localhost:9090/test/foo/"), new Header[0]));
+  }
+}


### PR DESCRIPTION
I had a temporary bug in my usage of this nice lib that is likely caused by Spotify replying with a 4xx or 5xx status code that was handled by the lib as 2xx status code.