### PR TITLE
feat: add `include_groups` parameter to `GetArtistsAlbumsRequest`

### DIFF
--- a/src/main/java/se/michaelthelin/spotify/requests/data/artists/GetArtistsAlbumsRequest.java
+++ b/src/main/java/se/michaelthelin/spotify/requests/data/artists/GetArtistsAlbumsRequest.java
@@ -75,11 +75,28 @@ public class GetArtistsAlbumsRequest extends AbstractDataRequest<Paging<AlbumSim
      *                   supplied, all album types will be returned. Valid values are: {@code album}, {@code single},
      *                   {@code appears_on} and {@code compilation}.
      * @return A {@link GetArtistsAlbumsRequest.Builder}.
+     * @deprecated Use {@link #include_groups(String)} instead.
      */
+    @Deprecated
     public Builder album_type(final String album_type) {
       assert (album_type != null);
       assert (album_type.matches("((^|,)(single|album|appears_on|compilation))+$"));
       return setQueryParameter("album_type", album_type);
+    }
+
+    /**
+     * The include groups filter setter.
+     *
+     * @param include_groups Optional. A comma-separated list of keywords that will be used to filter the response. If not
+     *                   supplied, all album types will be returned. Valid values are: {@code album}, {@code single},
+     *                   {@code appears_on} and {@code compilation}.
+     * @return A {@link GetArtistsAlbumsRequest.Builder}.
+     * @see <a href="https://developer.spotify.com/documentation/web-api/reference/get-an-artists-albums">Spotify Web API References / Get Artist's Albums</a>
+     */
+    public Builder include_groups(final String include_groups) {
+      assert (include_groups != null);
+      assert (include_groups.matches("((^|,)(single|album|appears_on|compilation))+$"));
+      return setQueryParameter("include_groups", include_groups);
     }
 
     /**

--- a/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetArtistsAlbumsRequestTest.java
+++ b/src/test/java/se/michaelthelin/spotify/requests/data/artists/GetArtistsAlbumsRequestTest.java
@@ -22,7 +22,7 @@ public class GetArtistsAlbumsRequestTest extends AbstractDataTest<Paging<AlbumSi
     .setHttpManager(
       TestUtil.MockedHttpManager.returningJson(
         "requests/data/artists/GetArtistsAlbumsRequest.json"))
-    .album_type(ITest.ALBUM_TYPE)
+    .include_groups(ITest.ALBUM_TYPE)
     .limit(ITest.LIMIT)
     .market(ITest.MARKET)
     .offset(ITest.OFFSET)
@@ -35,7 +35,7 @@ public class GetArtistsAlbumsRequestTest extends AbstractDataTest<Paging<AlbumSi
   public void shouldComplyWithReference() {
     assertHasAuthorizationHeader(defaultRequest);
     assertEquals(
-      "https://api.spotify.com:443/v1/artists/0LcJLqbBmaGUft1e9Mm8HV/albums?album_type=album&limit=10&market=SE&offset=0",
+      "https://api.spotify.com:443/v1/artists/0LcJLqbBmaGUft1e9Mm8HV/albums?include_groups=album&limit=10&market=SE&offset=0",
       defaultRequest.getUri().toString());
   }
 


### PR DESCRIPTION
The `album_type` parameter has no effect and also
the [documentation](https://developer.spotify.com/documentation/web-api/reference/get-an-artists-albums) only mentions `include_groups`