### PR TITLE
feat!: implement closeable for client and http manager

### DIFF
--- a/src/main/java/se/michaelthelin/spotify/IHttpManager.java
+++ b/src/main/java/se/michaelthelin/spotify/IHttpManager.java
@@ -5,13 +5,14 @@ import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.ParseException;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.net.URI;
 
 /**
  * A simple HTTP connection interface.
  */
-public interface IHttpManager {
+public interface IHttpManager extends Closeable {
 
   /**
    * Perform an HTTP GET request to the specified URL.

--- a/src/main/java/se/michaelthelin/spotify/SpotifyApi.java
+++ b/src/main/java/se/michaelthelin/spotify/SpotifyApi.java
@@ -39,6 +39,8 @@ import se.michaelthelin.spotify.requests.data.tracks.*;
 import se.michaelthelin.spotify.requests.data.users_profile.GetCurrentUsersProfileRequest;
 import se.michaelthelin.spotify.requests.data.users_profile.GetUsersProfileRequest;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.net.URI;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -49,7 +51,7 @@ import java.util.logging.Logger;
 /**
  * Instances of the SpotifyApi class provide access to the Spotify Web API.
  */
-public class SpotifyApi {
+public class SpotifyApi implements Closeable {
 
   /**
    * The default authentication host of Spotify API calls.
@@ -1906,6 +1908,11 @@ public class SpotifyApi {
     return new GetUsersProfileRequest.Builder(accessToken)
       .setDefaults(httpManager, scheme, host, port)
       .user_id(user_id);
+  }
+
+  @Override
+  public void close() throws IOException {
+    httpManager.close();
   }
 
   /**

--- a/src/main/java/se/michaelthelin/spotify/SpotifyHttpManager.java
+++ b/src/main/java/se/michaelthelin/spotify/SpotifyHttpManager.java
@@ -26,6 +26,7 @@ import org.apache.hc.core5.util.Timeout;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.exceptions.detailed.*;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -35,7 +36,7 @@ import java.util.logging.Level;
  * Default implementation of the {@link IHttpManager} interface.
  * Manages HTTP requests to the Spotify Web API using Apache HttpClient.
  */
-public class SpotifyHttpManager implements IHttpManager {
+public class SpotifyHttpManager implements IHttpManager, Closeable {
 
   private static final Gson GSON = new Gson();
   private final CloseableHttpClient httpClient;
@@ -335,6 +336,13 @@ public class SpotifyHttpManager implements IHttpManager {
     }
 
     return response;
+  }
+
+  @Override
+  public void close() throws IOException {
+    httpClient.close();
+    httpClientCaching.close();
+    connectionManager.close();
   }
 
   private String getResponseBody(CloseableHttpResponse httpResponse) throws


### PR DESCRIPTION
In case a user wants to free up resources held by the spotify api client, I suggest to implement the `Closeable` interface.