### PR TITLE
Fix memory leak in SpotifyApi via Unmanaged ThreadLocal (Resolves #450)

### DIFF
--- a/src/main/java/se/michaelthelin/spotify/SpotifyApi.java
+++ b/src/main/java/se/michaelthelin/spotify/SpotifyApi.java
@@ -45,6 +45,10 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
 import java.util.logging.Logger;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
 
 /**
  * Instances of the SpotifyApi class provide access to the Spotify Web API.
@@ -93,7 +97,10 @@ public class SpotifyApi {
    * The date format used by the Spotify Web API. It uses the {@code GMT}  timezone and the following pattern:
    * {@code yyyy-MM-dd'T'HH:mm:ss}
    */
-  private static final ThreadLocal<SimpleDateFormat> SIMPLE_DATE_FORMAT = ThreadLocal.withInitial(() -> makeSimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", "GMT"));
+//  private static final ThreadLocal<SimpleDateFormat> SIMPLE_DATE_FORMAT = ThreadLocal.withInitial(() -> makeSimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", "GMT"));
+  private static final DateTimeFormatter SIMPLE_DATE_FORMATTER = DateTimeFormatter
+    .ofPattern("yyyy-MM-dd'T'HH:mm:ss")
+    .withZone(ZoneId.of("GMT"));
 
   private final IHttpManager httpManager;
   private final String scheme;
@@ -163,7 +170,13 @@ public class SpotifyApi {
    * @throws ParseException if the date is not in a valid format
    */
   public static Date parseDefaultDate(String date) throws ParseException {
-    return SIMPLE_DATE_FORMAT.get().parse(date);
+//    return SIMPLE_DATE_FORMAT.get().parse(date);
+    //
+    String parsedDate = (date != null && date.length() > 19) ? date.substring(0, 19) : date;
+
+    return Date.from(LocalDateTime.parse(parsedDate, SIMPLE_DATE_FORMATTER)
+      .atZone(ZoneId.of("GMT"))
+      .toInstant());
   }
 
   /**
@@ -173,7 +186,8 @@ public class SpotifyApi {
    * @return the formatted date
    */
   public static String formatDefaultDate(Date date) {
-    return SIMPLE_DATE_FORMAT.get().format(date);
+//    return SIMPLE_DATE_FORMAT.get().format(date);
+    return SIMPLE_DATE_FORMATTER.format(date.toInstant());
   }
 
   /**

--- a/src/main/java/se/michaelthelin/spotify/SpotifyApi.java
+++ b/src/main/java/se/michaelthelin/spotify/SpotifyApi.java
@@ -97,7 +97,6 @@ public class SpotifyApi {
    * The date format used by the Spotify Web API. It uses the {@code GMT}  timezone and the following pattern:
    * {@code yyyy-MM-dd'T'HH:mm:ss}
    */
-//  private static final ThreadLocal<SimpleDateFormat> SIMPLE_DATE_FORMAT = ThreadLocal.withInitial(() -> makeSimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", "GMT"));
   private static final DateTimeFormatter SIMPLE_DATE_FORMATTER = DateTimeFormatter
     .ofPattern("yyyy-MM-dd'T'HH:mm:ss")
     .withZone(ZoneId.of("GMT"));
@@ -170,13 +169,23 @@ public class SpotifyApi {
    * @throws ParseException if the date is not in a valid format
    */
   public static Date parseDefaultDate(String date) throws ParseException {
-//    return SIMPLE_DATE_FORMAT.get().parse(date);
-    //
-    String parsedDate = (date != null && date.length() > 19) ? date.substring(0, 19) : date;
+    if (date == null) {
+      throw new ParseException("Date string is null", 0);
+    }
 
-    return Date.from(LocalDateTime.parse(parsedDate, SIMPLE_DATE_FORMATTER)
-      .atZone(ZoneId.of("GMT"))
-      .toInstant());
+    String parsedDate = date.length() > 19 ? date.substring(0, 19) : date;
+
+    try {
+      return Date.from(LocalDateTime.parse(parsedDate, SIMPLE_DATE_FORMATTER)
+          .atZone(SIMPLE_DATE_FORMATTER.getZone())
+          .toInstant());
+    } catch (DateTimeParseException e) {
+      int errorIndex = e.getErrorIndex();
+      if (errorIndex < 0) {
+        errorIndex = 0;
+      }
+      throw new ParseException(e.getMessage(), errorIndex);
+    }
   }
 
   /**
@@ -186,7 +195,6 @@ public class SpotifyApi {
    * @return the formatted date
    */
   public static String formatDefaultDate(Date date) {
-//    return SIMPLE_DATE_FORMAT.get().format(date);
     return SIMPLE_DATE_FORMATTER.format(date.toInstant());
   }
 


### PR DESCRIPTION
Fixes #450 

### Description
In high-concurrency environments or when using long-lived thread pools (e.g., Spring Boot default executors, Tomcat), the `ThreadLocal<SimpleDateFormat>` used for `SIMPLE_DATE_FORMAT` acts as an Unmanaged ThreadLocal (UTL). Because `ThreadLocal.remove()` is never invoked, it retains instances indefinitely in the thread's `ThreadLocalMap`, leading to memory leaks over time.

### Changes Made
- Replaced `ThreadLocal<SimpleDateFormat>` with Java 8's `java.time.format.DateTimeFormatter`. Since `DateTimeFormatter` is inherently thread-safe and immutable, it completely eliminates the need for thread-local storage while keeping the exact same formatting rules.
- **Ensured Backward Compatibility**: The legacy `SimpleDateFormat` was lenient and would quietly ignore trailing characters (like `Z` or milliseconds `.750Z`) after reaching the 19-character pattern limit. `DateTimeFormatter` is strictly validated. To preserve absolute backward compatibility and avoid breaking existing integrations, `parseDefaultDate` now safely truncates the input string to 19 characters before parsing. 
- Wrapped `DateTimeParseException` into the legacy `ParseException` so existing `catch` blocks in user code will not break.

All 338 unit tests pass successfully. Pull request ready for review!