### PR TITLE
feat: add common interfaces

### DIFF
--- a/src/main/java/se/michaelthelin/spotify/model_objects/interfaces/IAlbum.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/interfaces/IAlbum.java
@@ -1,0 +1,99 @@
+package se.michaelthelin.spotify.model_objects.interfaces;
+
+import se.michaelthelin.spotify.enums.AlbumType;
+import se.michaelthelin.spotify.enums.ModelObjectType;
+import se.michaelthelin.spotify.enums.ReleaseDatePrecision;
+import se.michaelthelin.spotify.model_objects.specification.Album;
+import se.michaelthelin.spotify.model_objects.specification.AlbumSimplified;
+import se.michaelthelin.spotify.model_objects.specification.ArtistSimplified;
+import se.michaelthelin.spotify.model_objects.specification.ExternalUrl;
+import se.michaelthelin.spotify.model_objects.specification.Image;
+import se.michaelthelin.spotify.model_objects.special.AlbumSimplifiedSpecial;
+
+/**
+ * Represents the common properties of Spotify Album objects (full and simplified).
+ *
+ * <p>This interface provides a common base for {@link Album}, {@link AlbumSimplified},
+ * and {@link AlbumSimplifiedSpecial} objects.
+ */
+public interface IAlbum {
+  /**
+   * Get the type of the album.
+   *
+   * @return The {@link AlbumType}.
+   */
+  AlbumType getAlbumType();
+
+  /**
+   * Get the artists of the album.
+   *
+   * @return An array of {@link ArtistSimplified} objects.
+   */
+  ArtistSimplified[] getArtists();
+
+  /**
+   * Get the external URLs of the album. <br>
+   * Example: <a href="https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids">Spotify-URL</a>
+   *
+   * @return An {@link ExternalUrl} object.
+   */
+  ExternalUrl getExternalUrls();
+
+  /**
+   * Get the full Spotify Web API endpoint URL of the album.
+   *
+   * @return A Spotify Web API endpoint URL.
+   */
+  String getHref();
+
+  /**
+   * Get the Spotify ID of the album.
+   *
+   * @return A <a href="https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids">Spotify album ID</a>.
+   */
+  String getId();
+
+  /**
+   * Get the album cover art of the album in different sizes.
+   *
+   * @return An array of {@link Image} objects.
+   */
+  Image[] getImages();
+
+  /**
+   * Get the name of the album.
+   *
+   * @return Album name.
+   */
+  String getName();
+
+  /**
+   * Get the release date of the album with the highest precision available.
+   *
+   * @return The release date of the album.
+   */
+  String getReleaseDate();
+
+  /**
+   * Get the precision of the albums release date. This is needed when the exact release day of an album is not known.
+   *
+   * @return The precision of the albums release date.
+   */
+  ReleaseDatePrecision getReleaseDatePrecision();
+
+  /**
+   * Get the model object type. In this case "album".
+   *
+   * @return A {@link ModelObjectType}.
+   */
+  ModelObjectType getType();
+
+  /**
+   * Get the Spotify URI of the album.
+   *
+   * @return <a href="https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids">Spotify album URI</a>.
+   */
+  String getUri();
+}
+
+

--- a/src/main/java/se/michaelthelin/spotify/model_objects/interfaces/IArtist.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/interfaces/IArtist.java
@@ -1,0 +1,59 @@
+package se.michaelthelin.spotify.model_objects.interfaces;
+
+import se.michaelthelin.spotify.enums.ModelObjectType;
+import se.michaelthelin.spotify.model_objects.specification.Artist;
+import se.michaelthelin.spotify.model_objects.specification.ArtistSimplified;
+import se.michaelthelin.spotify.model_objects.specification.ExternalUrl;
+
+/**
+ * Represents the common properties of Spotify Artist objects (full and simplified).
+ *
+ * <p>This interface provides a common base for {@link Artist} and
+ * {@link ArtistSimplified} objects.
+ */
+public interface IArtist {
+  /**
+   * Get the external URLs of the artist. <br>
+   * Example: <a href="https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids">Spotify-URL</a>
+   *
+   * @return An {@link ExternalUrl} object.
+   */
+  ExternalUrl getExternalUrls();
+
+  /**
+   * Get the full Spotify Web API endpoint URL of the artist.
+   *
+   * @return A Spotify Web API endpoint URL.
+   */
+  String getHref();
+
+  /**
+   * Get the Spotify ID of the artist.
+   *
+   * @return A <a href="https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids">Spotify artist ID</a>.
+   */
+  String getId();
+
+  /**
+   * Get the name of the artist.
+   *
+   * @return Artist name.
+   */
+  String getName();
+
+  /**
+   * Get the model object type. In this case "artist".
+   *
+   * @return A {@link ModelObjectType}.
+   */
+  ModelObjectType getType();
+
+  /**
+   * Get the Spotify URI of the artist.
+   *
+   * @return <a href="https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids">Spotify artist URI</a>.
+   */
+  String getUri();
+}
+
+

--- a/src/main/java/se/michaelthelin/spotify/model_objects/interfaces/IEpisode.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/interfaces/IEpisode.java
@@ -1,0 +1,91 @@
+package se.michaelthelin.spotify.model_objects.interfaces;
+
+import se.michaelthelin.spotify.enums.ReleaseDatePrecision;
+import se.michaelthelin.spotify.model_objects.IPlaylistItem;
+import se.michaelthelin.spotify.model_objects.specification.Episode;
+import se.michaelthelin.spotify.model_objects.specification.EpisodeSimplified;
+import se.michaelthelin.spotify.model_objects.specification.Image;
+import se.michaelthelin.spotify.model_objects.specification.ResumePoint;
+
+/**
+ * Represents the common properties of Spotify Episode objects (full and simplified).
+ *
+ * <p>This interface extends {@link IPlaylistItem} and provides a common base for
+ * {@link Episode} and
+ * {@link EpisodeSimplified}
+ * objects.
+ */
+public interface IEpisode extends IPlaylistItem {
+  /**
+   * Get a link to a 30 second preview (MP3 format) of the episode. {@code null} if not available.
+   *
+   * @return A link to a 30 second preview (MP3 format) of the episode. {@code null} if not available.
+   */
+  String getAudioPreviewUrl();
+
+  /**
+   * Get a description of the episode.
+   *
+   * @return The description of the episode.
+   */
+  String getDescription();
+
+  /**
+   * Check whether the episode is explicit or not.
+   *
+   * @return Whether or not the episode has explicit content ({@code true} = yes it does; {@code false} = no it does not
+   *         <b>OR</b> unknown).
+   */
+  Boolean getExplicit();
+
+  /**
+   * Get the cover art for the episode in various sizes, widest first.
+   *
+   * @return An array of {@link Image} objects.
+   */
+  Image[] getImages();
+
+  /**
+   * Check whether the episode is hosted outside of Spotify's CDN.
+   *
+   * @return True if the episode is hosted outside of Spotify's CDN.
+   */
+  Boolean getExternallyHosted();
+
+  /**
+   * Check whether the episode is playable in the given market.
+   *
+   * @return True if the episode is playable in the given market. Otherwise false.
+   */
+  Boolean getPlayable();
+
+  /**
+   * Get a list of the languages used in the episode, identified by their ISO 639 code.
+   *
+   * @return An array of <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1 alpha-2 country codes</a>.
+   */
+  String[] getLanguages();
+
+  /**
+   * Get the date the episode was first released, for example "1981-12-15". Depending on the precision, it might be shown as "1981" or "1981-12".
+   *
+   * @return The release date of the episode.
+   */
+  String getReleaseDate();
+
+  /**
+   * Get the precision with which the release date is known.
+   *
+   * @return A {@link ReleaseDatePrecision} object.
+   */
+  ReleaseDatePrecision getReleaseDatePrecision();
+
+  /**
+   * Get the user's most recent position in the episode. Set if the supplied access token is a user token and has the scope {@code user-read-playback-position}.
+   *
+   * @return A {@link ResumePoint} object.
+   */
+  ResumePoint getResumePoint();
+}
+
+

--- a/src/main/java/se/michaelthelin/spotify/model_objects/interfaces/IHasTotal.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/interfaces/IHasTotal.java
@@ -1,0 +1,17 @@
+package se.michaelthelin.spotify.model_objects.interfaces;
+
+/**
+ * Represents an object that has a total count.
+ * <p>
+ * This interface is implemented by objects that provide a total count of items,
+ * such as playlists or other paging objects.
+ */
+public interface IHasTotal {
+  /**
+   * Get the total count.
+   *
+   * @return The total count of items
+   */
+  Integer getTotal();
+}
+

--- a/src/main/java/se/michaelthelin/spotify/model_objects/interfaces/IPlaylist.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/interfaces/IPlaylist.java
@@ -89,6 +89,13 @@ public interface IPlaylist {
   Boolean getIsPublicAccess();
 
   /**
+   * Get information about the items in the playlist. The concrete type depends on the specific playlist object type.
+   *
+   * @return Item information containing total count.
+   */
+  IHasTotal getItems();
+
+  /**
    * Get the snapshot ID, the version identifier for the current playlist. Can be supplied in other requests to target
    * a specific playlist version.
    *

--- a/src/main/java/se/michaelthelin/spotify/model_objects/interfaces/IPlaylist.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/interfaces/IPlaylist.java
@@ -12,8 +12,13 @@ import se.michaelthelin.spotify.model_objects.specification.User;
  *
  * <p>This interface provides a common base for {@link Playlist} and
  * {@link PlaylistSimplified} objects.
+ *
+ * @param <T> The concrete type of the items/tracks metadata object. {@link Playlist} uses
+ *            {@link se.michaelthelin.spotify.model_objects.specification.Paging} and
+ *            {@link PlaylistSimplified} uses
+ *            {@link se.michaelthelin.spotify.model_objects.miscellaneous.PlaylistTracksInformation}.
  */
-public interface IPlaylist {
+public interface IPlaylist<T extends IHasTotal> {
   /**
    * Check whether the owner allows other users to modify the playlist.
    *
@@ -93,7 +98,7 @@ public interface IPlaylist {
    *
    * @return Item information containing total count.
    */
-  IHasTotal getItems();
+  T getItems();
 
   /**
    * Get the snapshot ID, the version identifier for the current playlist. Can be supplied in other requests to target

--- a/src/main/java/se/michaelthelin/spotify/model_objects/interfaces/IPlaylist.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/interfaces/IPlaylist.java
@@ -1,0 +1,116 @@
+package se.michaelthelin.spotify.model_objects.interfaces;
+
+import se.michaelthelin.spotify.enums.ModelObjectType;
+import se.michaelthelin.spotify.model_objects.specification.ExternalUrl;
+import se.michaelthelin.spotify.model_objects.specification.Image;
+import se.michaelthelin.spotify.model_objects.specification.Playlist;
+import se.michaelthelin.spotify.model_objects.specification.PlaylistSimplified;
+import se.michaelthelin.spotify.model_objects.specification.User;
+
+/**
+ * Represents the common properties of Spotify Playlist objects (full and simplified).
+ *
+ * <p>This interface provides a common base for {@link Playlist} and
+ * {@link PlaylistSimplified} objects.
+ */
+public interface IPlaylist {
+  /**
+   * Check whether the owner allows other users to modify the playlist.
+   *
+   * @return {@code true} if other users are allowed to modify the playlist, {@code false} otherwise.
+   * @see <a href="https://developer.spotify.com/documentation/web-api/concepts/playlists">
+   *      Spotify: Working With Playlists</a>
+   */
+  Boolean getIsCollaborative();
+
+  /**
+   * Get the description of the playlist.
+   *
+   * @return The playlist description. Only returned for modified, verified playlists, otherwise {@code null}.
+   */
+  String getDescription();
+
+  /**
+   * Get the external URLs of the playlist. <br>
+   * Example: Spotify-URL.
+   *
+   * @return Known external URLs for this playlist.
+   */
+  ExternalUrl getExternalUrls();
+
+  /**
+   * Get the full Spotify API endpoint url of the playlist.
+   *
+   * @return A link to the Web API endpoint providing full details of the playlist.
+   */
+  String getHref();
+
+  /**
+   * Get the <a href="https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids">Spotify ID</a>
+   * of a playlist.
+   *
+   * @return The Spotify ID for the playlist.
+   */
+  String getId();
+
+  /**
+   * Images for the playlist. The array may be empty or contain up to three images. The images are returned by size in
+   * descending order. <br>
+   * <b>Note:</b> If returned, the source URL for the image is temporary and will expire in less than a day.
+   *
+   * @return An array of images in different sizes.
+   * @see <a href="https://developer.spotify.com/documentation/web-api/concepts/playlists">
+   *      Spotify: Working With Playlists</a>
+   */
+  Image[] getImages();
+
+  /**
+   * Get the name of a playlist.
+   *
+   * @return Playlist name.
+   */
+  String getName();
+
+  /**
+   * Get the owners user object of a playlist.
+   *
+   * @return A user object.
+   */
+  User getOwner();
+
+  /**
+   * Check whether a playlist is available in public or is private.
+   *
+   * @return {@code true} the playlist is public, {@code false} the playlist is private, {@code null}
+   *         the playlist status is not relevant.
+   * @see <a href="https://developer.spotify.com/documentation/web-api/concepts/playlists">
+   *      Spotify: Working With Playlists</a>
+   */
+  Boolean getIsPublicAccess();
+
+  /**
+   * Get the snapshot ID, the version identifier for the current playlist. Can be supplied in other requests to target
+   * a specific playlist version.
+   *
+   * @return The version identifier for the current playlist.
+   * @see se.michaelthelin.spotify.requests.data.playlists.RemoveItemsFromPlaylistRequest
+   */
+  String getSnapshotId();
+
+  /**
+   * Get the model object type. In this case "playlist".
+   *
+   * @return The object type: "playlist"
+   */
+  ModelObjectType getType();
+
+  /**
+   * Get the <a href="https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids">Spotify URI</a>
+   * of a playlist.
+   *
+   * @return Spotify playlist URI.
+   */
+  String getUri();
+}
+
+

--- a/src/main/java/se/michaelthelin/spotify/model_objects/interfaces/IShow.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/interfaces/IShow.java
@@ -1,0 +1,110 @@
+package se.michaelthelin.spotify.model_objects.interfaces;
+
+import se.michaelthelin.spotify.enums.ModelObjectType;
+import se.michaelthelin.spotify.model_objects.specification.Copyright;
+import se.michaelthelin.spotify.model_objects.specification.ExternalUrl;
+import se.michaelthelin.spotify.model_objects.specification.Image;
+import se.michaelthelin.spotify.model_objects.specification.Show;
+import se.michaelthelin.spotify.model_objects.specification.ShowSimplified;
+
+/**
+ * Represents the common properties of Spotify Show objects (full and simplified).
+ *
+ * <p>This interface provides a common base for {@link Show} and
+ * {@link ShowSimplified} objects.
+ */
+public interface IShow {
+  /**
+   * Get all copyright texts of the show.
+   *
+   * @return An array of {@link Copyright} objects.
+   */
+  Copyright[] getCopyrights();
+
+  /**
+   * Get a description of the show.
+   *
+   * @return The description of the show.
+   */
+  String getDescription();
+
+  /**
+   * Check whether the show is explicit or not.
+   *
+   * @return Whether or not the show has explicit content ({@code true} = yes it does; {@code false} = no it does not
+   *         <b>OR</b> unknown).
+   */
+  Boolean getExplicit();
+
+  /**
+   * Get the external URLs of the show. <br>
+   * Example: <a href="https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids">Spotify-URL</a>
+   *
+   * @return An {@link ExternalUrl} object.
+   */
+  ExternalUrl getExternalUrls();
+
+  /**
+   * Get the full Spotify Web API endpoint URL of the show.
+   *
+   * @return A link to the Web API endpoint providing full details of the show.
+   */
+  String getHref();
+
+  /**
+   * Get the Spotify ID of the show.
+   *
+   * @return A <a href="https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids">Spotify show ID</a>.
+   */
+  String getId();
+
+  /**
+   * Get the cover art for the show in various sizes, widest first.
+   *
+   * @return An array of {@link Image} objects.
+   */
+  Image[] getImages();
+
+  /**
+   * Check whether the show is hosted outside of Spotify's CDN.
+   *
+   * @return True if the show is hosted outside of Spotify's CDN. Might be {@code null} in some cases.
+   */
+  Boolean getExternallyHosted();
+
+  /**
+   * Get a list of the languages used in the show, identified by their ISO 639 code.
+   *
+   * @return An array of <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1 alpha-2 country codes</a>.
+   */
+  String[] getLanguages();
+
+  /**
+   * Get the media type of the show.
+   *
+   * @return The media type of the show.
+   */
+  String getMediaType();
+
+  /**
+   * Get the name of the show.
+   *
+   * @return The name of the show.
+   */
+  String getName();
+
+  /**
+   * Get the model object type. In this case "show".
+   *
+   * @return A {@link ModelObjectType}.
+   */
+  ModelObjectType getType();
+
+  /**
+   * Get the Spotify URI of the show.
+   *
+   * @return <a href="https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids">Spotify show URI</a>.
+   */
+  String getUri();
+}
+

--- a/src/main/java/se/michaelthelin/spotify/model_objects/interfaces/ITrack.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/interfaces/ITrack.java
@@ -1,0 +1,66 @@
+package se.michaelthelin.spotify.model_objects.interfaces;
+
+import se.michaelthelin.spotify.model_objects.IPlaylistItem;
+import se.michaelthelin.spotify.model_objects.specification.ArtistSimplified;
+import se.michaelthelin.spotify.model_objects.specification.Track;
+import se.michaelthelin.spotify.model_objects.specification.TrackSimplified;
+
+/**
+ * Represents the common properties of Spotify Track objects (full and simplified).
+ *
+ * <p>This interface extends {@link IPlaylistItem} and provides a common base for
+ * {@link Track} and
+ * {@link TrackSimplified}
+ * objects.
+ */
+public interface ITrack extends IPlaylistItem {
+  /**
+   * Get the artists who performed the track.
+   *
+   * @return The artists who performed the track. Each artist object includes a link in {@code href} to more detailed
+   *         information about the artist.
+   */
+  ArtistSimplified[] getArtists();
+
+  /**
+   * Get the disc number of the track in its album.
+   *
+   * @return The disc number (usually 1 unless the album consists of more than one disc).
+   */
+  Integer getDiscNumber();
+
+  /**
+   * Check whether the track is explicit or not.
+   *
+   * @return Whether or not the track has explicit lyrics ({@code true} = yes it does; {@code false} = no it does not
+   *         <b>OR</b> unknown).
+   */
+  Boolean getIsExplicit();
+
+  /**
+   * Check whether the track is playable in the market, which may has been specified somewhere before requesting it.
+   * Part of the response when <a href="https://developer.spotify.com/documentation/web-api/concepts/track-relinking">
+   * Track Relinking</a> is applied.
+   *
+   * @return If {@code true}, the track is playable in the given market. Otherwise {@code false}.
+   */
+  Boolean getIsPlayable();
+
+  /**
+   * Get a link to a 30 second preview (MP3 format) of the track. {@code null} if not available.
+   *
+   * @return A link to a 30 second preview (MP3 format) of the track. {@code null} if not available.
+   */
+  String getPreviewUrl();
+
+  /**
+   * Get the track number of the track. If an album has several discs, the track number is the number on the specified
+   * disc.
+   *
+   * @return The number of the track.
+   */
+  Integer getTrackNumber();
+}
+
+
+

--- a/src/main/java/se/michaelthelin/spotify/model_objects/miscellaneous/PlaylistTracksInformation.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/miscellaneous/PlaylistTracksInformation.java
@@ -3,12 +3,13 @@ package se.michaelthelin.spotify.model_objects.miscellaneous;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.gson.JsonObject;
 import se.michaelthelin.spotify.model_objects.AbstractModelObject;
+import se.michaelthelin.spotify.model_objects.interfaces.IHasTotal;
 
 /**
  * Retrieve information about Playlist Track Information objects by building instances from this class.
  */
 @JsonDeserialize(builder = PlaylistTracksInformation.Builder.class)
-public class PlaylistTracksInformation extends AbstractModelObject {
+public class PlaylistTracksInformation extends AbstractModelObject implements IHasTotal {
   /** A link to the Web API endpoint where full details of the playlist's tracks can be retrieved. */
   private final String href;
   /** Number of tracks in the playlist. */

--- a/src/main/java/se/michaelthelin/spotify/model_objects/special/AlbumSimplifiedSpecial.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/special/AlbumSimplifiedSpecial.java
@@ -12,6 +12,7 @@ import se.michaelthelin.spotify.model_objects.specification.Album;
 import se.michaelthelin.spotify.model_objects.specification.ArtistSimplified;
 import se.michaelthelin.spotify.model_objects.specification.ExternalUrl;
 import se.michaelthelin.spotify.model_objects.specification.Image;
+import se.michaelthelin.spotify.model_objects.interfaces.IAlbum;
 import se.michaelthelin.spotify.requests.data.search.interfaces.ISearchModelObject;
 
 import java.util.Arrays;
@@ -25,7 +26,7 @@ import java.util.Objects;
  * specification, although the albums object as returned by the searches API includes it.
  */
 @JsonDeserialize(builder = AlbumSimplifiedSpecial.Builder.class)
-public class AlbumSimplifiedSpecial extends AbstractModelObject implements ISearchModelObject {
+public class AlbumSimplifiedSpecial extends AbstractModelObject implements ISearchModelObject, IAlbum {
   /** The type of the album. */
   private final AlbumType albumType;
   /** The artists who performed the album. */

--- a/src/main/java/se/michaelthelin/spotify/model_objects/special/AlbumSimplifiedSpecial.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/special/AlbumSimplifiedSpecial.java
@@ -8,11 +8,11 @@ import se.michaelthelin.spotify.enums.AlbumType;
 import se.michaelthelin.spotify.enums.ModelObjectType;
 import se.michaelthelin.spotify.enums.ReleaseDatePrecision;
 import se.michaelthelin.spotify.model_objects.AbstractModelObject;
+import se.michaelthelin.spotify.model_objects.interfaces.IAlbum;
 import se.michaelthelin.spotify.model_objects.specification.Album;
 import se.michaelthelin.spotify.model_objects.specification.ArtistSimplified;
 import se.michaelthelin.spotify.model_objects.specification.ExternalUrl;
 import se.michaelthelin.spotify.model_objects.specification.Image;
-import se.michaelthelin.spotify.model_objects.interfaces.IAlbum;
 import se.michaelthelin.spotify.requests.data.search.interfaces.ISearchModelObject;
 
 import java.util.Arrays;

--- a/src/main/java/se/michaelthelin/spotify/model_objects/specification/Album.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/specification/Album.java
@@ -7,6 +7,7 @@ import se.michaelthelin.spotify.enums.AlbumType;
 import se.michaelthelin.spotify.enums.ModelObjectType;
 import se.michaelthelin.spotify.enums.ReleaseDatePrecision;
 import se.michaelthelin.spotify.model_objects.AbstractModelObject;
+import se.michaelthelin.spotify.model_objects.interfaces.IAlbum;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -16,7 +17,7 @@ import java.util.Objects;
  * Album objects</a> by building instances from this class.
  */
 @JsonDeserialize(builder = Album.Builder.class)
-public class Album extends AbstractModelObject {
+public class Album extends AbstractModelObject implements IAlbum {
   /** The type of the album. */
   private final AlbumType albumType;
   /** The artists who performed the album. */

--- a/src/main/java/se/michaelthelin/spotify/model_objects/specification/AlbumSimplified.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/specification/AlbumSimplified.java
@@ -7,6 +7,7 @@ import se.michaelthelin.spotify.enums.ModelObjectType;
 import se.michaelthelin.spotify.enums.ReleaseDatePrecision;
 import se.michaelthelin.spotify.model_objects.AbstractModelObject;
 import se.michaelthelin.spotify.model_objects.miscellaneous.Restrictions;
+import se.michaelthelin.spotify.model_objects.interfaces.IAlbum;
 import se.michaelthelin.spotify.requests.data.search.interfaces.ISearchModelObject;
 
 import java.util.Arrays;
@@ -17,7 +18,7 @@ import java.util.Objects;
  * simplified Album objects</a> by building instances from this class.
  */
 @JsonDeserialize(builder = AlbumSimplified.Builder.class)
-public class AlbumSimplified extends AbstractModelObject implements ISearchModelObject {
+public class AlbumSimplified extends AbstractModelObject implements ISearchModelObject, IAlbum {
   /** The type of the album. */
   private final AlbumType albumType;
   /** The artists who performed the album. */

--- a/src/main/java/se/michaelthelin/spotify/model_objects/specification/AlbumSimplified.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/specification/AlbumSimplified.java
@@ -6,8 +6,8 @@ import se.michaelthelin.spotify.enums.AlbumType;
 import se.michaelthelin.spotify.enums.ModelObjectType;
 import se.michaelthelin.spotify.enums.ReleaseDatePrecision;
 import se.michaelthelin.spotify.model_objects.AbstractModelObject;
-import se.michaelthelin.spotify.model_objects.miscellaneous.Restrictions;
 import se.michaelthelin.spotify.model_objects.interfaces.IAlbum;
+import se.michaelthelin.spotify.model_objects.miscellaneous.Restrictions;
 import se.michaelthelin.spotify.requests.data.search.interfaces.ISearchModelObject;
 
 import java.util.Arrays;

--- a/src/main/java/se/michaelthelin/spotify/model_objects/specification/Artist.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/specification/Artist.java
@@ -5,6 +5,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import se.michaelthelin.spotify.enums.ModelObjectType;
 import se.michaelthelin.spotify.model_objects.AbstractModelObject;
+import se.michaelthelin.spotify.model_objects.interfaces.IArtist;
 import se.michaelthelin.spotify.requests.data.personalization.interfaces.IArtistTrackModelObject;
 import se.michaelthelin.spotify.requests.data.search.interfaces.ISearchModelObject;
 
@@ -16,7 +17,7 @@ import java.util.Objects;
  * Artist objects</a> by building instances from this class.
  */
 @JsonDeserialize(builder = Artist.Builder.class)
-public class Artist extends AbstractModelObject implements IArtistTrackModelObject, ISearchModelObject {
+public class Artist extends AbstractModelObject implements IArtistTrackModelObject, ISearchModelObject, IArtist {
   /** Known external URLs for this artist. */
   private final ExternalUrl externalUrls;
   /** A list of the genres the artist is associated with. */

--- a/src/main/java/se/michaelthelin/spotify/model_objects/specification/ArtistSimplified.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/specification/ArtistSimplified.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.gson.JsonObject;
 import se.michaelthelin.spotify.enums.ModelObjectType;
 import se.michaelthelin.spotify.model_objects.AbstractModelObject;
+import se.michaelthelin.spotify.model_objects.interfaces.IArtist;
 
 import java.util.Objects;
 
@@ -12,7 +13,7 @@ import java.util.Objects;
  * simplified Artist objects</a> by building instances from this class.
  */
 @JsonDeserialize(builder = ArtistSimplified.Builder.class)
-public class ArtistSimplified extends AbstractModelObject {
+public class ArtistSimplified extends AbstractModelObject implements IArtist {
   /** Known external URLs for this artist. */
   private final ExternalUrl externalUrls;
   /** A link to the Web API endpoint providing full details of the artist. */

--- a/src/main/java/se/michaelthelin/spotify/model_objects/specification/Episode.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/specification/Episode.java
@@ -7,6 +7,7 @@ import se.michaelthelin.spotify.enums.ModelObjectType;
 import se.michaelthelin.spotify.enums.ReleaseDatePrecision;
 import se.michaelthelin.spotify.model_objects.AbstractModelObject;
 import se.michaelthelin.spotify.model_objects.IPlaylistItem;
+import se.michaelthelin.spotify.model_objects.interfaces.IEpisode;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -16,7 +17,7 @@ import java.util.Objects;
  * episode objects</a> by building instances from this class.
  */
 @JsonDeserialize(builder = Episode.Builder.class)
-public class Episode extends AbstractModelObject implements IPlaylistItem {
+public class Episode extends AbstractModelObject implements IPlaylistItem, IEpisode {
   /** The audio preview URL for the episode. */
   private final String audioPreviewUrl;
   /** The description of the episode. */

--- a/src/main/java/se/michaelthelin/spotify/model_objects/specification/Episode.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/specification/Episode.java
@@ -6,7 +6,6 @@ import com.google.gson.JsonObject;
 import se.michaelthelin.spotify.enums.ModelObjectType;
 import se.michaelthelin.spotify.enums.ReleaseDatePrecision;
 import se.michaelthelin.spotify.model_objects.AbstractModelObject;
-import se.michaelthelin.spotify.model_objects.IPlaylistItem;
 import se.michaelthelin.spotify.model_objects.interfaces.IEpisode;
 
 import java.util.Arrays;
@@ -17,7 +16,7 @@ import java.util.Objects;
  * episode objects</a> by building instances from this class.
  */
 @JsonDeserialize(builder = Episode.Builder.class)
-public class Episode extends AbstractModelObject implements IPlaylistItem, IEpisode {
+public class Episode extends AbstractModelObject implements IEpisode {
   /** The audio preview URL for the episode. */
   private final String audioPreviewUrl;
   /** The description of the episode. */

--- a/src/main/java/se/michaelthelin/spotify/model_objects/specification/EpisodeSimplified.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/specification/EpisodeSimplified.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonObject;
 import se.michaelthelin.spotify.enums.ModelObjectType;
 import se.michaelthelin.spotify.enums.ReleaseDatePrecision;
 import se.michaelthelin.spotify.model_objects.AbstractModelObject;
+import se.michaelthelin.spotify.model_objects.interfaces.IEpisode;
 import se.michaelthelin.spotify.requests.data.search.interfaces.ISearchModelObject;
 
 import java.util.Arrays;
@@ -16,7 +17,7 @@ import java.util.Objects;
  * simplified Episode objects</a> by building instances from this class.
  */
 @JsonDeserialize(builder = EpisodeSimplified.Builder.class)
-public class EpisodeSimplified extends AbstractModelObject implements ISearchModelObject {
+public class EpisodeSimplified extends AbstractModelObject implements ISearchModelObject, IEpisode {
   /** The audio preview URL for the episode. */
   private final String audioPreviewUrl;
   /** The description of the episode. */

--- a/src/main/java/se/michaelthelin/spotify/model_objects/specification/Paging.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/specification/Paging.java
@@ -3,6 +3,7 @@ package se.michaelthelin.spotify.model_objects.specification;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.gson.JsonObject;
 import se.michaelthelin.spotify.model_objects.AbstractModelObject;
+import se.michaelthelin.spotify.model_objects.interfaces.IHasTotal;
 
 import java.lang.reflect.ParameterizedType;
 import java.util.Arrays;
@@ -16,7 +17,7 @@ import java.util.Arrays;
  * @param <T> The type of the objects contained in a paging object.
  */
 @JsonDeserialize(builder = Paging.Builder.class)
-public class Paging<T> extends AbstractModelObject {
+public class Paging<T> extends AbstractModelObject implements IHasTotal {
   /** The Spotify Web API endpoint URL. */
   private final String href;
   /** Array of items in the paging object. */

--- a/src/main/java/se/michaelthelin/spotify/model_objects/specification/PagingCursorbased.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/specification/PagingCursorbased.java
@@ -3,6 +3,7 @@ package se.michaelthelin.spotify.model_objects.specification;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.gson.JsonObject;
 import se.michaelthelin.spotify.model_objects.AbstractModelObject;
+import se.michaelthelin.spotify.model_objects.interfaces.IHasTotal;
 
 import java.lang.reflect.ParameterizedType;
 import java.util.Arrays;
@@ -16,7 +17,7 @@ import java.util.Arrays;
  * @param <T> The type of the objects contained in a paging object.
  */
 @JsonDeserialize(builder = PagingCursorbased.Builder.class)
-public class PagingCursorbased<T> extends AbstractModelObject {
+public class PagingCursorbased<T> extends AbstractModelObject implements IHasTotal {
   /** The Spotify Web API endpoint URL. */
   private final String href;
   /** Array of items in the paging object. */

--- a/src/main/java/se/michaelthelin/spotify/model_objects/specification/Playlist.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/specification/Playlist.java
@@ -15,7 +15,7 @@ import java.util.Objects;
  * Playlist objects</a> by building instances from this class.
  */
 @JsonDeserialize(builder = Playlist.Builder.class)
-public class Playlist extends AbstractModelObject implements IPlaylist {
+public class Playlist extends AbstractModelObject implements IPlaylist<Paging<PlaylistTrack>> {
   /** Whether the playlist is collaborative. */
   private final Boolean collaborative;
   /** The description of the playlist. */

--- a/src/main/java/se/michaelthelin/spotify/model_objects/specification/Playlist.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/specification/Playlist.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.gson.JsonObject;
 import se.michaelthelin.spotify.enums.ModelObjectType;
 import se.michaelthelin.spotify.model_objects.AbstractModelObject;
+import se.michaelthelin.spotify.model_objects.interfaces.IPlaylist;
 import se.michaelthelin.spotify.requests.data.playlists.RemoveItemsFromPlaylistRequest;
 
 import java.util.Arrays;
@@ -14,7 +15,7 @@ import java.util.Objects;
  * Playlist objects</a> by building instances from this class.
  */
 @JsonDeserialize(builder = Playlist.Builder.class)
-public class Playlist extends AbstractModelObject {
+public class Playlist extends AbstractModelObject implements IPlaylist {
   /** Whether the playlist is collaborative. */
   private final Boolean collaborative;
   /** The description of the playlist. */

--- a/src/main/java/se/michaelthelin/spotify/model_objects/specification/PlaylistSimplified.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/specification/PlaylistSimplified.java
@@ -17,7 +17,7 @@ import java.util.Objects;
  * simplified Playlist objects</a> by building instances from this class.
  */
 @JsonDeserialize(builder = PlaylistSimplified.Builder.class)
-public class PlaylistSimplified extends AbstractModelObject implements ISearchModelObject, IPlaylist {
+public class PlaylistSimplified extends AbstractModelObject implements ISearchModelObject, IPlaylist<PlaylistTracksInformation> {
   /** Whether the playlist is collaborative. */
   private final Boolean collaborative;
   /** The description of the playlist. */

--- a/src/main/java/se/michaelthelin/spotify/model_objects/specification/PlaylistSimplified.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/specification/PlaylistSimplified.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonObject;
 import se.michaelthelin.spotify.enums.ModelObjectType;
 import se.michaelthelin.spotify.model_objects.AbstractModelObject;
 import se.michaelthelin.spotify.model_objects.miscellaneous.PlaylistTracksInformation;
+import se.michaelthelin.spotify.model_objects.interfaces.IPlaylist;
 import se.michaelthelin.spotify.requests.data.playlists.RemoveItemsFromPlaylistRequest;
 import se.michaelthelin.spotify.requests.data.search.interfaces.ISearchModelObject;
 
@@ -16,7 +17,7 @@ import java.util.Objects;
  * simplified Playlist objects</a> by building instances from this class.
  */
 @JsonDeserialize(builder = PlaylistSimplified.Builder.class)
-public class PlaylistSimplified extends AbstractModelObject implements ISearchModelObject {
+public class PlaylistSimplified extends AbstractModelObject implements ISearchModelObject, IPlaylist {
   /** Whether the playlist is collaborative. */
   private final Boolean collaborative;
   /** The description of the playlist. */

--- a/src/main/java/se/michaelthelin/spotify/model_objects/specification/PlaylistSimplified.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/specification/PlaylistSimplified.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.gson.JsonObject;
 import se.michaelthelin.spotify.enums.ModelObjectType;
 import se.michaelthelin.spotify.model_objects.AbstractModelObject;
-import se.michaelthelin.spotify.model_objects.miscellaneous.PlaylistTracksInformation;
 import se.michaelthelin.spotify.model_objects.interfaces.IPlaylist;
+import se.michaelthelin.spotify.model_objects.miscellaneous.PlaylistTracksInformation;
 import se.michaelthelin.spotify.requests.data.playlists.RemoveItemsFromPlaylistRequest;
 import se.michaelthelin.spotify.requests.data.search.interfaces.ISearchModelObject;
 

--- a/src/main/java/se/michaelthelin/spotify/model_objects/specification/Show.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/specification/Show.java
@@ -5,6 +5,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import se.michaelthelin.spotify.enums.ModelObjectType;
 import se.michaelthelin.spotify.model_objects.AbstractModelObject;
+import se.michaelthelin.spotify.model_objects.interfaces.IShow;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -14,7 +15,7 @@ import java.util.Objects;
  * Show objects</a> by building instances from this class.
  */
 @JsonDeserialize(builder = Show.Builder.class)
-public class Show extends AbstractModelObject {
+public class Show extends AbstractModelObject implements IShow {
   /** The copyright statements of the show. */
   private final Copyright[] copyrights;
   /** A description of the show. */

--- a/src/main/java/se/michaelthelin/spotify/model_objects/specification/ShowSimplified.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/specification/ShowSimplified.java
@@ -5,6 +5,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import se.michaelthelin.spotify.enums.ModelObjectType;
 import se.michaelthelin.spotify.model_objects.AbstractModelObject;
+import se.michaelthelin.spotify.model_objects.interfaces.IShow;
 import se.michaelthelin.spotify.requests.data.search.interfaces.ISearchModelObject;
 
 import java.util.Arrays;
@@ -15,7 +16,7 @@ import java.util.Objects;
  * simplified Show objects</a> by building instances from this class.
  */
 @JsonDeserialize(builder = ShowSimplified.Builder.class)
-public class ShowSimplified extends AbstractModelObject implements ISearchModelObject {
+public class ShowSimplified extends AbstractModelObject implements ISearchModelObject, IShow {
   /** The copyright statements of the show. */
   private final Copyright[] copyrights;
   /** A description of the show. */

--- a/src/main/java/se/michaelthelin/spotify/model_objects/specification/Track.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/specification/Track.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.gson.JsonObject;
 import se.michaelthelin.spotify.enums.ModelObjectType;
 import se.michaelthelin.spotify.model_objects.AbstractModelObject;
-import se.michaelthelin.spotify.model_objects.miscellaneous.Restrictions;
 import se.michaelthelin.spotify.model_objects.interfaces.ITrack;
+import se.michaelthelin.spotify.model_objects.miscellaneous.Restrictions;
 import se.michaelthelin.spotify.requests.data.personalization.interfaces.IArtistTrackModelObject;
 import se.michaelthelin.spotify.requests.data.search.interfaces.ISearchModelObject;
 

--- a/src/main/java/se/michaelthelin/spotify/model_objects/specification/Track.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/specification/Track.java
@@ -6,6 +6,7 @@ import se.michaelthelin.spotify.enums.ModelObjectType;
 import se.michaelthelin.spotify.model_objects.AbstractModelObject;
 import se.michaelthelin.spotify.model_objects.IPlaylistItem;
 import se.michaelthelin.spotify.model_objects.miscellaneous.Restrictions;
+import se.michaelthelin.spotify.model_objects.interfaces.ITrack;
 import se.michaelthelin.spotify.requests.data.personalization.interfaces.IArtistTrackModelObject;
 import se.michaelthelin.spotify.requests.data.search.interfaces.ISearchModelObject;
 
@@ -17,7 +18,7 @@ import java.util.Objects;
  * Track objects</a> by building instances from this class.
  */
 @JsonDeserialize(builder = Track.Builder.class)
-public class Track extends AbstractModelObject implements IArtistTrackModelObject, ISearchModelObject, IPlaylistItem {
+public class Track extends AbstractModelObject implements IArtistTrackModelObject, ISearchModelObject, IPlaylistItem, ITrack {
   /** The album on which the track appears. */
   private final AlbumSimplified album;
   /** The artists who performed the track. */

--- a/src/main/java/se/michaelthelin/spotify/model_objects/specification/Track.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/specification/Track.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.gson.JsonObject;
 import se.michaelthelin.spotify.enums.ModelObjectType;
 import se.michaelthelin.spotify.model_objects.AbstractModelObject;
-import se.michaelthelin.spotify.model_objects.IPlaylistItem;
 import se.michaelthelin.spotify.model_objects.miscellaneous.Restrictions;
 import se.michaelthelin.spotify.model_objects.interfaces.ITrack;
 import se.michaelthelin.spotify.requests.data.personalization.interfaces.IArtistTrackModelObject;
@@ -18,7 +17,7 @@ import java.util.Objects;
  * Track objects</a> by building instances from this class.
  */
 @JsonDeserialize(builder = Track.Builder.class)
-public class Track extends AbstractModelObject implements IArtistTrackModelObject, ISearchModelObject, IPlaylistItem, ITrack {
+public class Track extends AbstractModelObject implements IArtistTrackModelObject, ISearchModelObject, ITrack {
   /** The album on which the track appears. */
   private final AlbumSimplified album;
   /** The artists who performed the track. */

--- a/src/main/java/se/michaelthelin/spotify/model_objects/specification/TrackSimplified.java
+++ b/src/main/java/se/michaelthelin/spotify/model_objects/specification/TrackSimplified.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.gson.JsonObject;
 import se.michaelthelin.spotify.enums.ModelObjectType;
 import se.michaelthelin.spotify.model_objects.AbstractModelObject;
+import se.michaelthelin.spotify.model_objects.interfaces.ITrack;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -13,7 +14,7 @@ import java.util.Objects;
  * simplified Track objects</a> by building instances from this class.
  */
 @JsonDeserialize(builder = TrackSimplified.Builder.class)
-public class TrackSimplified extends AbstractModelObject {
+public class TrackSimplified extends AbstractModelObject implements ITrack {
   /** The artists who performed the track. */
   private final ArtistSimplified[] artists;
   /** The disc number. */


### PR DESCRIPTION
I'm working on a project, where I'm sometimes getting a `PlaylistSimplified` and sometimes a `Playlist`. As I only need the basic properties, it would save me a lot of boilerplate code if I could downcast both classes to `IPlaylist` instead of writing my own conversion methods and model classes. 

Therefore, this pull request introduces new interfaces to unify the representation of Spotify model objects (Album, Artist, Playlist, Show, Episode, and Track), and updates the corresponding model classes to implement these interfaces. This especially benefits applications implementing this library by providing common interfaces for full and simplified versions of model objects.

I've added no tests, as interfaces only provide the contract, not the implementation, and the model class specific implementations are already tested.

The change is done in a way it shouldn't break any code of existing applications. I've targeted the `beta` branch and would be happy if this PR could be included in the final v10 release.